### PR TITLE
Hide older downloads and documentation from the main page

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -5,6 +5,12 @@ header:
   - url: /roadmap
     title: Roadmap
     identifier: roadmap
+  - url: /documentation
+    title: Documentation
+    identifier: documentation
+  - url: /downloads
+    title: Downloads
+    identifier: downloads
   - url: /blog
     title: Blog
     identifier: blog

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,0 +1,19 @@
+---
+layout: default
+---
+
+# Documentation
+
+## Latest release
+
+* [0.3.1](/docs/0.3.1/)
+
+## Master
+
+* [Master](/docs/master/)
+
+## Older releases
+
+* [0.3.0](/docs/0.3.0/)
+* [0.2.0](/docs/0.2.0/)
+* [0.1.0](/docs/0.1.0/README.md)

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -1,0 +1,19 @@
+---
+layout: default
+---
+
+# Downloads
+
+Strimzi releases are available for download on our [GitHub](https://github.com/strimzi/strimzi). The release artifacts
+contain documentation and example YAML files for deployment on OpenShift and Kubernetes. The Docker images are
+available on [Docker Hub](https://hub.docker.com/u/strimzi/).
+
+## Latest release
+
+* [0.3.1](https://github.com/strimzi/strimzi/releases/tag/0.3.1)
+
+## Older releases
+
+* [0.3.0](https://github.com/strimzi/strimzi/releases/tag/0.3.0)
+* [0.2.0](https://github.com/strimzi/strimzi/releases/tag/0.2.0)
+* [0.1.0](https://github.com/strimzi/strimzi/releases/tag/0.1.0)

--- a/index.md
+++ b/index.md
@@ -11,24 +11,22 @@ Strimzi provides a way to run an [Apache Kafka](https://kafka.apache.org/) clust
 
 See our [GitHub](http://github.com/strimzi) repository for more info.
 
-# Downloads / Releases
+# Downloads
 
 Strimzi releases are available for download on our [GitHub](https://github.com/strimzi/strimzi). The release artifacts
 contain documentation and example YAML files for deployment on OpenShift and Kubernetes. The Docker images are
 available on [Docker Hub](https://hub.docker.com/u/strimzi/).
 
 * [0.3.1](https://github.com/strimzi/strimzi/releases/tag/0.3.1)
-* [0.3.0](https://github.com/strimzi/strimzi/releases/tag/0.3.0)
-* [0.2.0](https://github.com/strimzi/strimzi/releases/tag/0.2.0)
-* [0.1.0](https://github.com/strimzi/strimzi/releases/tag/0.1.0)
+
+Older releases can found in the [Downloads](/downloads) page
 
 # Documentation
 
 * [Master](/docs/master/)
 * [0.3.1](/docs/0.3.1/)
-* [0.3.0](/docs/0.3.0/)
-* [0.2.0](/docs/0.2.0/)
-* [0.1.0](/docs/0.1.0/README.md)
+
+Documentation for older releases can found in the [Documentation](/documentation) page
 
 # Getting help
 

--- a/index.md
+++ b/index.md
@@ -19,14 +19,14 @@ available on [Docker Hub](https://hub.docker.com/u/strimzi/).
 
 * [0.3.1](https://github.com/strimzi/strimzi/releases/tag/0.3.1)
 
-Older releases can found in the [Downloads](/downloads) page
+Older releases can be found in the [Downloads](/downloads) page
 
 # Documentation
 
 * [Master](/docs/master/)
 * [0.3.1](/docs/0.3.1/)
 
-Documentation for older releases can found in the [Documentation](/documentation) page
+Documentation for older releases can be found in the [Documentation](/documentation) page
 
 # Getting help
 


### PR DESCRIPTION
Related to strimzi/strimzi#356, this PR creates two new sub-pages Downloads and Documentation. These pages will contain all links to all versions of Strimzi. On the main page, we would keep only the latest release + documentation for master. WDYT?