### PR TITLE
Correct header logo dimensions

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
 </div>
 <div align="center">
     <br />
-    <img alt="Strimzi" src="https://raw.githubusercontent.com/strimzi/strimzi/master/documentation/logo/strimzi.png" height="30%" width="30%" />
+    <img alt="Strimzi" src="https://raw.githubusercontent.com/strimzi/strimzi/master/documentation/logo/strimzi.png" height="30%" />
 </div>
 </br>
 <nav>


### PR DESCRIPTION
The logo looks squashed with the current 30% width / 30% height dimensions.
Removed the width so that the logo keeps its original aspect ratio.