### PR TITLE
Add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+I have:
+
+* [ ] Checked that the problem is not about the Strimzi documentation.
+  Documentation issues (those with URLs starting http://strimzi.io/docs/...) should be reported [here](https://github.com/strimzi/strimzi-kafka-operator/issues/new).
+* [ ] Included the URL of the page my issue is about
+* [ ] Described what I did see and what I was expecting to see 


### PR DESCRIPTION
This PR adds an issue template to the website repo, directing issues about docs to the strimzi-kafka-operator repo.