### PR TITLE
Add initial Helm Chart repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repository contains the [Strimzi website](http://strimzi.io).
 
 [Ruby](https://www.ruby-lang.org/en/) and [Rubygems](https://rubygems.org/) are needed in order to build the web site.
 
+Install [bundler](https://bundler.io/)
+
+    gem install bundler
+
 ## Build
 
 In order to build and serve the web site locally, run :

--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+entries:
+  strimzi-kafka-operator:
+  - apiVersion: v1
+    appVersion: 0.6.0
+    created: 2018-08-23T14:25:34.526805221-04:00
+    description: 'Strimzi: Kafka as a Service'
+    digest: 684868a46604411a151d90579f15e065320ba636c2afd25702b508fe11b30c64
+    home: http://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    keywords:
+    - kafka
+    - queue
+    - stream
+    - event
+    - messaging
+    - datastore
+    - topic
+    maintainers:
+    - name: ppatierno
+    - name: scholzj
+    - name: tombentley
+    name: strimzi-kafka-operator
+    sources:
+    - https://github.com/strimzi/strimzi-kafka-operator
+    urls:
+    - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
+    version: 0.6.0
+  - apiVersion: v1
+    appVersion: 0.6.0-rc3
+    created: 2018-08-23T14:22:34.723706021-04:00
+    description: 'Strimzi: Kafka as a Service'
+    digest: f21f51f0611da940d987911f760ed4ed8bf3d6aaa6de0ba2207630cee7d97b19
+    home: http://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/master/documentation/logo/strimzi_logo.png
+    keywords:
+    - kafka
+    - queue
+    - stream
+    - event
+    - messaging
+    - datastore
+    - topic
+    maintainers:
+    - name: ppatierno
+    - name: scholzj
+    - name: tombentley
+    name: strimzi-kafka-operator
+    sources:
+    - https://github.com/strimzi/strimzi-kafka-operator
+    urls:
+    - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0-rc3/strimzi-kafka-operator-0.6.0-rc3.tgz
+    version: 0.6.0-rc3
+generated: 2018-08-23T14:25:34.526112491-04:00


### PR DESCRIPTION
Add Helm Chart repository index.yaml with valid previous chart releases.

See project PR for more details: https://github.com/strimzi/strimzi-kafka-operator/pull/801