### PR TITLE
First set of quickstarts (OKD and minikube)

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -5,6 +5,9 @@ header:
   - url: /roadmap
     title: Roadmap
     identifier: roadmap
+  - url: /quickstarts
+    title: Quickstarts
+    identifier: quickstarts
   - url: /documentation
     title: Documentation
     identifier: documentation

--- a/index.md
+++ b/index.md
@@ -27,6 +27,7 @@ Older releases can be found in the [Downloads](/downloads) page.
 
 # Documentation
 
+* [Quickstarts](/quickstarts)
 * [Master](/docs/master/)
 * [0.8.0](/docs/0.8.0/)
 

--- a/quickstarts/index.md
+++ b/quickstarts/index.md
@@ -1,0 +1,8 @@
+# Strimzi Quickstart
+
+Getting up and running with a Apache Kafka cluster on Kubernetes and OKD can be very simple, when using the Strimzi project! 
+
+Below are a few quickstart documents for different environments, that walk you through a quick and easy install for your development environment:
+
+* [Minikube](/quickstarts/minikube/)
+* [OKD](/quickstarts/okd)

--- a/quickstarts/index.md
+++ b/quickstarts/index.md
@@ -1,6 +1,6 @@
 # Strimzi Quickstart
 
-Getting up and running with an Apache Kafka cluster on Kubernetes and OKD can be very simple, when using the Strimzi project! 
+Getting up and running with an Apache Kafka cluster on Kubernetes and OKD (the Origin Community Distribution of Kubernetes that powers Red Hat OpenShift) can be very simple, when using the Strimzi project! 
 
 Below are a few quickstart documents for different environments, that walk you through a quick and easy install for your development environment:
 

--- a/quickstarts/index.md
+++ b/quickstarts/index.md
@@ -1,6 +1,6 @@
 # Strimzi Quickstart
 
-Getting up and running with a Apache Kafka cluster on Kubernetes and OKD can be very simple, when using the Strimzi project! 
+Getting up and running with an Apache Kafka cluster on Kubernetes and OKD can be very simple, when using the Strimzi project! 
 
 Below are a few quickstart documents for different environments, that walk you through a quick and easy install for your development environment:
 

--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -1,0 +1,44 @@
+# Starting Minikube 
+
+This assumes that you have the latest version of the `minikube` binary, which you can get [here](https://kubernetes.io/docs/setup/minikube/#installation).
+
+```shell
+minikube start --memory=8192 --cpus=4 \
+  --kubernetes-version=v1.12.1 \
+  --vm-driver=kvm2 \
+  --bootstrapper=kubeadm \
+  --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+```
+
+This will start a local installation of Minikube. Once this is completed, let's create our `kafka` namespace:
+
+```shell
+kubectl create namespace kafka 
+```
+
+# Applying Strimzi installation file
+
+Next we are applying the Strimzi install files, including `ClusterRoles`, `ClusterRoleBindings` and some **Custom Resource Definitions** (`CRDs`) for the Apache Kafka itself, or creating Apache Kafka topics:
+
+```shell
+curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.1/strimzi-cluster-operator-0.8.1.yaml \
+  | sed 's/namespace: .*/namespace: kafka/' \
+  | kubectl -n kafka apply -f -
+```
+
+# Provision the Apache Kafka cluster
+
+Afterwards we feed Strimzi with a simple **Custom Resource**, which will than give you a simple, ephemeral Apache Kafka Cluster:
+
+```shell
+# Apply the `Kafka` Cluster CR file
+kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.8.1/examples/kafka/kafka-ephemeral.yaml -n kafka
+```
+
+We can now watch the deployment on the `kafka` namesapce, and see all required pods being created:
+
+```shell
+kubectl get pods -n kafka -w
+```
+
+Enjoy your Apache Kafka cluster, running on Minikube!

--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -3,14 +3,12 @@
 This assumes that you have the latest version of the `minikube` binary, which you can get [here](https://kubernetes.io/docs/setup/minikube/#installation).
 
 ```shell
-minikube start --memory=8192 --cpus=4 \
-  --kubernetes-version=v1.12.1 \
-  --vm-driver=kvm2 \
-  --bootstrapper=kubeadm \
-  --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+minikube start ...
 ```
 
-This will start a local installation of Minikube. Once this is completed, let's create our `kafka` namespace:
+> NOTE: Make sure to start `minikube` with your configured VM. If need help look at the [documentation](https://kubernetes.io/docs/setup/minikube/#quickstart) for more.
+
+Once Minikube this is started, let's create our `kafka` namespace:
 
 ```shell
 kubectl create namespace kafka 
@@ -21,7 +19,7 @@ kubectl create namespace kafka
 Next we apply the Strimzi install files, including `ClusterRoles`, `ClusterRoleBindings` and some **Custom Resource Definitions** (`CRDs`). The CRDs define the schemas used for declarative management of the Kafka cluster, Kafka topics and users.
 
 ```shell
-curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.1/strimzi-cluster-operator-0.8.1.yaml \
+curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.2/strimzi-cluster-operator-0.8.2.yaml \
   | sed 's/namespace: .*/namespace: kafka/' \
   | kubectl -n kafka apply -f -
 ```
@@ -32,13 +30,26 @@ After that we feed Strimzi with a simple **Custom Resource**, which will than gi
 
 ```shell
 # Apply the `Kafka` Cluster CR file
-kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.8.1/examples/kafka/kafka-ephemeral.yaml -n kafka
+kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.8.2/examples/kafka/kafka-persistent.yaml -n kafka
 ```
 
 We can now watch the deployment on the `kafka` namespace, and see all required pods being created:
 
 ```shell
 kubectl get pods -n kafka -w
+```
+
+The installation is complete, once the `my-cluster-entity-operator` is running, like:
+
+```
+my-cluster-entity-operator-6bc7f6985c-q29p5   3/3     Running   0          44s
+my-cluster-kafka-0                            2/2     Running   1          91s
+my-cluster-kafka-1                            2/2     Running   1          91s
+my-cluster-kafka-2                            2/2     Running   1          91s
+my-cluster-zookeeper-0                        2/2     Running   0          2m30s
+my-cluster-zookeeper-1                        2/2     Running   0          2m30s
+my-cluster-zookeeper-2                        2/2     Running   0          2m30s
+strimzi-cluster-operator-78f8bf857-kpmhb      1/1     Running   0          3m10s
 ```
 
 Enjoy your Apache Kafka cluster, running on Minikube!

--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -3,12 +3,12 @@
 This assumes that you have the latest version of the `minikube` binary, which you can get [here](https://kubernetes.io/docs/setup/minikube/#installation).
 
 ```shell
-minikube start ...
+minikube start
 ```
 
 > NOTE: Make sure to start `minikube` with your configured VM. If need help look at the [documentation](https://kubernetes.io/docs/setup/minikube/#quickstart) for more.
 
-Once Minikube this is started, let's create our `kafka` namespace:
+Once Minikube is started, let's create our `kafka` namespace:
 
 ```shell
 kubectl create namespace kafka 

--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -35,7 +35,7 @@ After that we feed Strimzi with a simple **Custom Resource**, which will than gi
 kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.8.1/examples/kafka/kafka-ephemeral.yaml -n kafka
 ```
 
-We can now watch the deployment on the `kafka` namesapce, and see all required pods being created:
+We can now watch the deployment on the `kafka` namespace, and see all required pods being created:
 
 ```shell
 kubectl get pods -n kafka -w

--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -18,7 +18,7 @@ kubectl create namespace kafka
 
 # Applying Strimzi installation file
 
-Next we are applying the Strimzi install files, including `ClusterRoles`, `ClusterRoleBindings` and some **Custom Resource Definitions** (`CRDs`) for the Apache Kafka itself, or creating Apache Kafka topics:
+Next we apply the Strimzi install files, including `ClusterRoles`, `ClusterRoleBindings` and some **Custom Resource Definitions** (`CRDs`). The CRDs define the schemas used for declarative management of the Kafka cluster, Kafka topics and users.
 
 ```shell
 curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.1/strimzi-cluster-operator-0.8.1.yaml \

--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -28,7 +28,7 @@ curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.
 
 # Provision the Apache Kafka cluster
 
-Afterwards we feed Strimzi with a simple **Custom Resource**, which will than give you a simple, ephemeral Apache Kafka Cluster:
+After that we feed Strimzi with a simple **Custom Resource**, which will than give you a simple, ephemeral Apache Kafka Cluster:
 
 ```shell
 # Apply the `Kafka` Cluster CR file

--- a/quickstarts/okd/index.md
+++ b/quickstarts/okd/index.md
@@ -6,7 +6,7 @@ This assumes that you have the latest version of the `oc` binary, which you can 
 oc cluster up
 ```
 
-This will start a local installation of OKD. Once this is completed, login as a `cluster-admin` user:
+This will start a local installation of [OKD](https://www.okd.io/), the Origin Community Distribution of Kubernetes that powers Red Hat OpenShift. Once this is completed, login as a `cluster-admin` user:
 
 ```shell
 # Install as cluster-admin
@@ -15,25 +15,38 @@ oc login -u system:admin
 
 # Applying Strimzi installation file
 
-Next we are applying the Strimzi install files, including `ClusterRoles`, `ClusterRoleBindings` and some **Custom Resource Definitions** (`CRDs`) for the Apache Kafka itself, or creating Apache Kafka topics:
+Next we apply the Strimzi install files, including `ClusterRoles`, `ClusterRoleBindings` and some **Custom Resource Definitions** (`CRDs`). The CRDs define the schemas used for declarative management of the Kafka cluster, Kafka topics and users.
 
 ```shell
-oc apply -f https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.1/strimzi-cluster-operator-0.8.1.yaml -n myproject
+oc apply -f https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.2/strimzi-cluster-operator-0.8.2.yaml -n myproject
 ```
 
 # Provision the Apache Kafka cluster
 
-Afterwards we feed Strimzi with a simple **Custom Resource**, which will than give you a simple, ephemeral Apache Kafka Cluster:
+After that we feed Strimzi with a simple **Custom Resource**, which will than give you a simple, ephemeral Apache Kafka Cluster:
 
 ```shell
 # Apply the `Kafka` Cluster CR file
-oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.8.1/examples/kafka/kafka-ephemeral.yaml -n myproject
+oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.8.2/examples/kafka/kafka-persistent.yaml -n myproject
 ```
 
 We can now watch the deployment on the `myproject` namesapce, and see all required pods being created:
 
 ```shell
 oc get pods -n myproject -w
+```
+
+The installation is complete, once the `my-cluster-entity-operator` is running, like:
+
+```
+my-cluster-entity-operator-6bc7f6985c-q29p5   3/3     Running   0          44s
+my-cluster-kafka-0                            2/2     Running   1          91s
+my-cluster-kafka-1                            2/2     Running   1          91s
+my-cluster-kafka-2                            2/2     Running   1          91s
+my-cluster-zookeeper-0                        2/2     Running   0          2m30s
+my-cluster-zookeeper-1                        2/2     Running   0          2m30s
+my-cluster-zookeeper-2                        2/2     Running   0          2m30s
+strimzi-cluster-operator-78f8bf857-kpmhb      1/1     Running   0          3m10s
 ```
 
 Enjoy your Apache Kafka cluster, running on OKD!

--- a/quickstarts/okd/index.md
+++ b/quickstarts/okd/index.md
@@ -1,0 +1,39 @@
+# Starting OKD 
+
+This assumes that you have the latest version of the `oc` binary, which you can get [here](https://github.com/OKD/origin/releases).
+
+```shell
+oc cluster up
+```
+
+This will start a local installation of OKD. Once this is completed, login as a `cluster-admin` user:
+
+```shell
+# Install as cluster-admin
+oc login -u system:admin
+```
+
+# Applying Strimzi installation file
+
+Next we are applying the Strimzi install files, including `ClusterRoles`, `ClusterRoleBindings` and some **Custom Resource Definitions** (`CRDs`) for the Apache Kafka itself, or creating Apache Kafka topics:
+
+```shell
+oc apply -f https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.8.1/strimzi-cluster-operator-0.8.1.yaml -n myproject
+```
+
+# Provision the Apache Kafka cluster
+
+Afterwards we feed Strimzi with a simple **Custom Resource**, which will than give you a simple, ephemeral Apache Kafka Cluster:
+
+```shell
+# Apply the `Kafka` Cluster CR file
+oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.8.1/examples/kafka/kafka-ephemeral.yaml -n myproject
+```
+
+We can now watch the deployment on the `myproject` namesapce, and see all required pods being created:
+
+```shell
+oc get pods -n myproject -w
+```
+
+Enjoy your Apache Kafka cluster, running on OKD!


### PR DESCRIPTION
Discussion:

a set of quickstarts, covering `minikube` and OKD (`oc cluster up`).

Uses simple, vanilla Strimzi - no extra feature (e.g. exposure)