### PR TITLE
Use https when pulling images from other domains.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -36,7 +36,7 @@
     <div class="container" id="companyfooter">
         <div class="redhatlogo" style="text-align:center;">
             <div id="logospacer"></div>
-            <a href="http://www.redhat.com/"><img alt="Red Hat" src="http://static.jboss.org/images/rhbar/redhatlogo.png"></a>
+            <a href="https://www.redhat.com/"><img alt="Red Hat" src="https://static.jboss.org/images/rhbar/redhatlogo.png"></a>
         </div>
     </div>
 </footer>  

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,8 +10,8 @@
 </script>
 <!-- Header bar with Red Hat and Red Hat Developer Program logos and links -->
 <div id="rhbar" style="height:40px;background-color: #202020">
-    <a href="http://developers.redhat.com" style="float: right;background-image: url(http://static.jboss.org/images/rhbar/rhd_reverse.png);background-repeat: no-repeat;height: 40px;width: 136px;"></a>
-    <a href="http://www.redhat.com/" style="float: right;background-image: url(http://static.jboss.org/images/rhbar/redhatlogo_reverse.png);background-repeat: no-repeat;height: 40px;width: 85px;"></a>
+    <a href="https://developers.redhat.com" style="float: right;background-image: url(https://static.jboss.org/images/rhbar/rhd_reverse.png);background-repeat: no-repeat;height: 40px;width: 136px;"></a>
+    <a href="https://www.redhat.com/" style="float: right;background-image: url(https://static.jboss.org/images/rhbar/redhatlogo_reverse.png);background-repeat: no-repeat;height: 40px;width: 85px;"></a>
 </div>
 <div align="center">
     <br />


### PR DESCRIPTION
Also use https links when external sites redirect http to https anyway.