### PR TITLE
Use {% raw %} to prevent Liquid/Jekyll warning

### DIFF
--- a/_posts/2019-03-07-strimzi-0.11.0-release.md
+++ b/_posts/2019-03-07-strimzi-0.11.0-release.md
@@ -163,6 +163,7 @@ The new Strimzi release provides the Kubernetes/OpenShift resources for deployin
 
 Here's an example snippet with an alert related to the under replicated partitions metric.
 
+{% raw %}
 ```yaml
 - alert: UnderReplicatedPartitions
   expr: kafka_server_replicamanager_underreplicatedpartitions > 0
@@ -173,6 +174,7 @@ Here's an example snippet with an alert related to the under replicated partitio
     summary: 'Kafka under replicated partitions'
     description: 'There are {{ $value }} under replicated partitions on {{ $labels.kubernetes_pod_name }}'
 ```
+{% endraw %}
 
 # ... and many more
 


### PR DESCRIPTION
This gets rid of the warning

Liquid Warning: Liquid syntax error (line 167): Unexpected character $ in "{{ $value }}" in /home/tom/messaging/strimzi.github.io/_posts/2019-03-07-strimzi-0.11.0-release.md

from Jekyll