### PR TITLE
Fix producer example image typo

### DIFF
--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -57,7 +57,7 @@ strimzi-cluster-operator-78f8bf857-kpmhb      1/1     Running   0          3m10s
 Once the cluster is running, you can run a simple producer to send messages to Kafka topic (the topic will be automatically created):
 
 ```shell
-kubectl -n kafka run kafka-producer -ti --image=strimzi/kafka{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9092 --topic my-topic
+kubectl -n kafka run kafka-producer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9092 --topic my-topic
 ```
 
 And to receive them:


### PR DESCRIPTION
Addresses failure to start Kakfa producer.

```Normal   Scheduled  7m21s  default-scheduler        Successfully assigned kafka/kafka-producer to docker-desktop
  Normal   Pulling    7m18s  kubelet, docker-desktop  Pulling image "strimzi/kafka0.12.1-kafka-2.2.1"
  Warning  Failed     7m18s  kubelet, docker-desktop  Failed to pull image "strimzi/kafka0.12.1-kafka-2.2.1": rpc error: code = Unknown desc = Error response from daemon: pull access denied for strimzi/kafka0.12.1-kafka-2.2.1, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
  Warning  Failed     7m18s  kubelet, docker-desktop  Error: ErrImagePull
```

