### PR TITLE
Tinker with quickstarts

### DIFF
--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -26,7 +26,7 @@ Next we apply the Strimzi install files, including `ClusterRoles`, `ClusterRoleB
 ```shell
 curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{site.data.releases.operator[0].version}}/strimzi-cluster-operator-{{site.data.releases.operator[0].version}}.yaml \
   | sed 's/namespace: .*/namespace: kafka/' \
-  | kubectl -n kafka apply -f -
+  | kubectl apply -f - -n kafka 
 ```
 
 # Provision the Apache Kafka cluster
@@ -35,13 +35,13 @@ After that we feed Strimzi with a simple **Custom Resource**, which will than gi
 
 ```shell
 # Apply the `Kafka` Cluster CR file
-kubectl -n kafka apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{{site.data.releases.operator[0].version}}/examples/kafka/kafka-persistent-single.yaml 
+kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{{site.data.releases.operator[0].version}}/examples/kafka/kafka-persistent-single.yaml -n kafka 
 ```
 
 We now need to wait while Kubernetes starts the required pods, services and so on:
 
 ```shell
-kubectl -n kafka wait --for=condition=Ready kafka/my-cluster --timeout=300s
+kubectl wait --for=condition=Ready kafka/my-cluster --timeout=300s -n kafka 
 ```
 
 The above command might timeout if you're downloading images over a slow connection. If that happens you can always run it again.

--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -1,4 +1,5 @@
 ---
+title: Minikube Quickstart
 layout: default
 ---
 
@@ -34,33 +35,26 @@ After that we feed Strimzi with a simple **Custom Resource**, which will than gi
 
 ```shell
 # Apply the `Kafka` Cluster CR file
-kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{{site.data.releases.operator[0].version}}/examples/kafka/kafka-persistent-single.yaml -n kafka
+kubectl -n kafka apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{{site.data.releases.operator[0].version}}/examples/kafka/kafka-persistent-single.yaml 
 ```
 
-We can now watch the deployment on the `kafka` namespace, and see all required pods being created:
+We now need to wait while Kubernetes starts the required pods, services and so on:
 
 ```shell
-kubectl get pods -n kafka -w
+kubectl -n kafka wait --for=condition=Ready kafka/my-cluster --timeout=300s
 ```
 
-The installation is complete, once the `my-cluster-entity-operator` is running, like:
-
-```
-my-cluster-entity-operator-6bc7f6985c-q29p5   3/3     Running   0          44s
-my-cluster-kafka-0                            2/2     Running   1          91s
-my-cluster-zookeeper-0                        2/2     Running   0          2m30s
-strimzi-cluster-operator-78f8bf857-kpmhb      1/1     Running   0          3m10s
-```
+The above command might timeout if you're downloading images over a slow connection. If that happens you can always run it again.
 
 # Send and receive messages
 
-Once the cluster is running, you can run a simple producer to send messages to Kafka topic (the topic will be automatically created):
+Once the cluster is running, you can run a simple producer to send messages to a Kafka topic (the topic will be automatically created):
 
 ```shell
 kubectl -n kafka run kafka-producer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9092 --topic my-topic
 ```
 
-And to receive them:
+And to receive them in a different terminal you can run:
 
 ```shell
 kubectl -n kafka run kafka-consumer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic my-topic --from-beginning

--- a/quickstarts/okd/index.md
+++ b/quickstarts/okd/index.md
@@ -23,7 +23,7 @@ oc login -u system:admin
 Next we apply the Strimzi install files, including `ClusterRoles`, `ClusterRoleBindings` and some **Custom Resource Definitions** (`CRDs`). The CRDs define the schemas used for declarative management of the Kafka cluster, Kafka topics and users.
 
 ```shell
-oc apply -n myproject -f https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{site.data.releases.operator[0].version}}/strimzi-cluster-operator-{{site.data.releases.operator[0].version}}.yaml 
+oc apply -f https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{site.data.releases.operator[0].version}}/strimzi-cluster-operator-{{site.data.releases.operator[0].version}}.yaml -n myproject
 ```
 
 # Provision the Apache Kafka cluster
@@ -32,13 +32,13 @@ After that we feed Strimzi with a simple **Custom Resource**, which will than gi
 
 ```shell
 # Apply the `Kafka` Cluster CR file
-oc apply -n myproject -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{{site.data.releases.operator[0].version}}/examples/kafka/kafka-persistent-single.yaml 
+oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{{site.data.releases.operator[0].version}}/examples/kafka/kafka-persistent-single.yaml -n myproject 
 ```
 
 We now need to wait while OpenShift starts the required pods, services and so on:
 
 ```shell
-ocwait -n myproject wait --for=condition=Ready kafka/my-cluster --timeout=300s
+oc wait wait --for=condition=Ready kafka/my-cluster --timeout=300s -n myproject
 ```
 
 The above command might timeout if you're downloading images over a slow connection. If that happens you can always run it again.
@@ -48,13 +48,13 @@ The above command might timeout if you're downloading images over a slow connect
 Once the cluster is running, you can run a simple producer to send messages to Kafka topic (the topic will be automatically created):
 
 ```shell
-oc run kafka-producer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9092 --topic my-topic
+oc -n kafka run kafka-producer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9092 --topic my-topic
 ```
 
 And to receive them in a different terminal you can run:
 
 ```shell
-oc run kafka-consumer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic my-topic --from-beginning
+oc -n kafka run kafka-consumer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic my-topic --from-beginning
 ```
 
 Enjoy your Apache Kafka cluster, running on OKD!


### PR DESCRIPTION
This PR:

* Uses `kubectl wait` instead of instructions to watch pods
* Puts `-n namespace` option in a consistent place
* Clarifies running producer and consumer in different terminals