### PR TITLE
Wrong namespace in the commands to run receiver and producer

### DIFF
--- a/quickstarts/okd/index.md
+++ b/quickstarts/okd/index.md
@@ -48,13 +48,13 @@ The above command might timeout if you're downloading images over a slow connect
 Once the cluster is running, you can run a simple producer to send messages to Kafka topic (the topic will be automatically created):
 
 ```shell
-oc -n kafka run kafka-producer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9092 --topic my-topic
+oc -n myproject run kafka-producer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list my-cluster-kafka-bootstrap:9092 --topic my-topic
 ```
 
 And to receive them in a different terminal you can run:
 
 ```shell
-oc -n kafka run kafka-consumer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic my-topic --from-beginning
+oc -n myproject run kafka-consumer -ti --image=strimzi/kafka:{{site.data.releases.operator[0].version}}-kafka-{{site.data.releases.operator[0].defaultKafkaVersion}} --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic my-topic --from-beginning
 ```
 
 Enjoy your Apache Kafka cluster, running on OKD!


### PR DESCRIPTION
The producer and receiver commands use the kafka namespace, while the kafka cluster in created in myproject namespace. I edited the producer and consumer commands replacing the kafka namespace with myproject.