### PR TITLE
Fixes on wait command in the quickstarts

### DIFF
--- a/quickstarts/minikube/index.md
+++ b/quickstarts/minikube/index.md
@@ -41,7 +41,7 @@ kubectl apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operato
 We now need to wait while Kubernetes starts the required pods, services and so on:
 
 ```shell
-kubectl wait --for=condition=Ready kafka/my-cluster --timeout=300s -n kafka 
+kubectl wait kafka/my-cluster --for=condition=Ready --timeout=300s -n kafka 
 ```
 
 The above command might timeout if you're downloading images over a slow connection. If that happens you can always run it again.

--- a/quickstarts/okd/index.md
+++ b/quickstarts/okd/index.md
@@ -38,7 +38,7 @@ oc apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/{{s
 We now need to wait while OpenShift starts the required pods, services and so on:
 
 ```shell
-oc wait wait --for=condition=Ready kafka/my-cluster --timeout=300s -n myproject
+oc wait kafka/my-cluster --for=condition=Ready --timeout=300s -n myproject
 ```
 
 The above command might timeout if you're downloading images over a slow connection. If that happens you can always run it again.


### PR DESCRIPTION
This PR fixes the `wait` command in the OKD quickstart and change the parameters order to follow the command help where the resource is provided before the options with "for conditions".