### PR TITLE
Fix version in 0.14.0 documentation

### DIFF
--- a/docs/0.14.0/0.14.0.html
+++ b/docs/0.14.0/0.14.0.html
@@ -1277,7 +1277,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -1354,7 +1354,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -1682,10 +1682,10 @@ You can add your own connectors by:</p>
 <div class="title">Procedure</div>
 <ol class="arabic">
 <li>
-<p>Create a new <code>Dockerfile</code> using <code>strimzi/kafka:latest-kafka-2.3.0</code> as the base image:</p>
+<p>Create a new <code>Dockerfile</code> using <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> as the base image:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code>FROM strimzi/kafka:latest-kafka-2.3.0
+<pre class="highlightjs highlight"><code>FROM strimzi/kafka:0.14.0-kafka-2.3.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -1735,7 +1735,7 @@ spec:
 <p>You can use OpenShift <a href="https://docs.okd.io/3.9/dev_guide/builds/index.html" target="_blank" rel="noopener">builds</a> and the  <a href="https://docs.okd.io/3.9/creating_images/s2i.html" target="_blank" rel="noopener">Source-to-Image (S2I)</a> framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift&#8217;s local container image repository and are available for use in deployments.</p>
 </div>
 <div class="paragraph">
-<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:latest-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
+<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
 </div>
 <div class="olist arabic">
 <div class="title">Procedure</div>
@@ -1924,7 +1924,7 @@ The Mirror Maker consumes messages from the source cluster and republishes those
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=strimzi/kafka:latest-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=strimzi/kafka:0.14.0-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
 </div>
 </div>
 </li>
@@ -1941,7 +1941,7 @@ The Mirror Maker consumes messages from the source cluster and republishes those
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=strimzi/kafka:latest-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=strimzi/kafka:0.14.0-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
 </div>
 </div>
 </li>
@@ -2260,19 +2260,19 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.1.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.1.0</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.1.1</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.1.1</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.2.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.2.0</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.2.1</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.2.1</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.3.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.3.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2304,7 +2304,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/operator:latest</p>
+<p>docker.io/strimzi/operator:0.14.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2333,7 +2333,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/kafka-bridge:latest</p>
+<p>docker.io/strimzi/kafka-bridge:0.14.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2417,7 +2417,7 @@ metadata:
 spec:
   kafka:
     replicas: 3 <b class="conum">(1)</b>
-    version: latest <b class="conum">(2)</b>
+    version: 0.14.0 <b class="conum">(2)</b>
     resources: <b class="conum">(3)</b>
       requests:
         memory: 64Gi
@@ -7013,7 +7013,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7026,7 +7026,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7039,7 +7039,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7052,7 +7052,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7065,7 +7065,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7078,7 +7078,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7091,7 +7091,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7104,7 +7104,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11166,7 +11166,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11179,7 +11179,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11192,7 +11192,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11205,7 +11205,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11218,7 +11218,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11231,7 +11231,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11244,7 +11244,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11257,7 +11257,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14110,7 +14110,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14123,7 +14123,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14136,7 +14136,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14149,7 +14149,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14162,7 +14162,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14175,7 +14175,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14188,7 +14188,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14201,7 +14201,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -15105,7 +15105,7 @@ For example:</p>
 <p>You can use OpenShift <a href="https://docs.okd.io/3.9/dev_guide/builds/index.html" target="_blank" rel="noopener">builds</a> and the  <a href="https://docs.okd.io/3.9/creating_images/s2i.html" target="_blank" rel="noopener">Source-to-Image (S2I)</a> framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift&#8217;s local container image repository and are available for use in deployments.</p>
 </div>
 <div class="paragraph">
-<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:latest-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
+<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
 </div>
 <div class="olist arabic">
 <div class="title">Procedure</div>
@@ -18268,7 +18268,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18281,7 +18281,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18294,7 +18294,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18307,7 +18307,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18320,7 +18320,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18333,7 +18333,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18346,7 +18346,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18359,7 +18359,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -19839,7 +19839,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -19916,7 +19916,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -20076,29 +20076,29 @@ increased when using Strimzi on clusters where regular Kubernetes operations tak
 <p>Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>Kafka.spec.kafka.version</code> property is specified but not the <code>Kafka.spec.kafka.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as default for the init container started before the broker for initial configuration work (that is, rack support), if no image is specified as the <code>kafka-init-image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for Kafka,
 if no image is specified as the <code>Kafka.spec.kafka.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying Zookeeper, if
 no image is specified as the <code>Kafka.spec.zookeeper.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for Zookeeper, if
 no image is specified as the <code>Kafka.spec.zookeeper.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
@@ -20107,7 +20107,7 @@ no image is specified as the <code>Kafka.spec.zookeeper.tlsSidecar.image</code> 
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaConnect.spec.version</code> property is specified but not the <code>KafkaConnect.spec.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka-connect">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_CONNECT_S2I_IMAGES</code></dt>
@@ -20115,7 +20115,7 @@ This is used when a <code>KafkaConnect.spec.version</code> property is specified
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaConnectS2I.spec.version</code> property is specified but not the <code>KafkaConnectS2I.spec.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka-connect-s2i">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_MIRROR_MAKER_IMAGES</code></dt>
@@ -20123,24 +20123,24 @@ This is used when a <code>KafkaConnectS2I.spec.version</code> property is specif
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaMirrorMaker.spec.version</code> property is specified but not the <code>KafkaMirrorMaker.spec.image</code>, as described in <a href="#con-configuring-container-images-deployment-configuration-kafka-mirror-maker">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as the default when deploying the topic operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.topicOperator.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a> of the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as the default when deploying the user operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.userOperator.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a> of the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the <code>Kafka.spec.entityOperator.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
@@ -25796,7 +25796,7 @@ The format can change between Kafka releases, so messages include a version iden
 <div class="sect2">
 <h3 id="assembly-upgrade-cluster-operator-str"><a class="link" href="#assembly-upgrade-cluster-operator-str">11.3. Upgrading the Cluster Operator</a></h3>
 <div class="paragraph">
-<p>The steps to upgrade your Cluster Operator deployment to use Strimzi latest are outlined in this section.</p>
+<p>The steps to upgrade your Cluster Operator deployment to use Strimzi 0.14.0 are outlined in this section.</p>
 </div>
 <div class="paragraph">
 <p>The availability of Kafka clusters managed by the Cluster Operator is not affected by the upgrade operation.</p>
@@ -26578,7 +26578,7 @@ You must format the value of <code>log.message.format.version</code> as a string
 <p>For this release of Strimzi, resources that use the API version <code>kafka.strimzi.io/v1alpha1</code> must be updated to use <code>kafka.strimzi.io/v1beta1</code>.</p>
 </div>
 <div class="paragraph">
-<p>The <code>kafka.strimzi.io/v1alpha1</code> API version is deprecated in release latest.</p>
+<p>The <code>kafka.strimzi.io/v1alpha1</code> API version is deprecated in release 0.14.0.</p>
 </div>
 <div class="paragraph">
 <p>This section describes the upgrade steps for the resources.</p>

--- a/docs/0.14.0/full.html
+++ b/docs/0.14.0/full.html
@@ -1714,7 +1714,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -1791,7 +1791,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -2119,10 +2119,10 @@ You can add your own connectors by:</p>
 <div class="title">Procedure</div>
 <ol class="arabic">
 <li>
-<p>Create a new <code>Dockerfile</code> using <code>strimzi/kafka:latest-kafka-2.3.0</code> as the base image:</p>
+<p>Create a new <code>Dockerfile</code> using <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> as the base image:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code>FROM strimzi/kafka:latest-kafka-2.3.0
+<pre class="highlightjs highlight"><code>FROM strimzi/kafka:0.14.0-kafka-2.3.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -2172,7 +2172,7 @@ spec:
 <p>You can use OpenShift <a href="https://docs.okd.io/3.9/dev_guide/builds/index.html" target="_blank" rel="noopener">builds</a> and the  <a href="https://docs.okd.io/3.9/creating_images/s2i.html" target="_blank" rel="noopener">Source-to-Image (S2I)</a> framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift&#8217;s local container image repository and are available for use in deployments.</p>
 </div>
 <div class="paragraph">
-<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:latest-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
+<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
 </div>
 <div class="olist arabic">
 <div class="title">Procedure</div>
@@ -2361,7 +2361,7 @@ The Mirror Maker consumes messages from the source cluster and republishes those
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=strimzi/kafka:latest-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=strimzi/kafka:0.14.0-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
 </div>
 </div>
 </li>
@@ -2378,7 +2378,7 @@ The Mirror Maker consumes messages from the source cluster and republishes those
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=strimzi/kafka:latest-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=strimzi/kafka:0.14.0-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
 </div>
 </div>
 </li>
@@ -2697,19 +2697,19 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.1.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.1.0</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.1.1</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.1.1</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.2.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.2.0</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.2.1</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.2.1</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.3.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.3.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2741,7 +2741,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/operator:latest</p>
+<p>docker.io/strimzi/operator:0.14.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2770,7 +2770,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/kafka-bridge:latest</p>
+<p>docker.io/strimzi/kafka-bridge:0.14.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2854,7 +2854,7 @@ metadata:
 spec:
   kafka:
     replicas: 3 <b class="conum">(1)</b>
-    version: latest <b class="conum">(2)</b>
+    version: 0.14.0 <b class="conum">(2)</b>
     resources: <b class="conum">(3)</b>
       requests:
         memory: 64Gi
@@ -7450,7 +7450,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7463,7 +7463,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7476,7 +7476,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7489,7 +7489,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7502,7 +7502,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7515,7 +7515,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7528,7 +7528,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7541,7 +7541,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11603,7 +11603,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11616,7 +11616,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11629,7 +11629,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11642,7 +11642,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11655,7 +11655,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11668,7 +11668,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11681,7 +11681,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11694,7 +11694,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14547,7 +14547,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14560,7 +14560,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14573,7 +14573,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14586,7 +14586,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14599,7 +14599,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14612,7 +14612,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14625,7 +14625,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14638,7 +14638,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -15542,7 +15542,7 @@ For example:</p>
 <p>You can use OpenShift <a href="https://docs.okd.io/3.9/dev_guide/builds/index.html" target="_blank" rel="noopener">builds</a> and the  <a href="https://docs.okd.io/3.9/creating_images/s2i.html" target="_blank" rel="noopener">Source-to-Image (S2I)</a> framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift&#8217;s local container image repository and are available for use in deployments.</p>
 </div>
 <div class="paragraph">
-<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:latest-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
+<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
 </div>
 <div class="olist arabic">
 <div class="title">Procedure</div>
@@ -18705,7 +18705,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18718,7 +18718,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18731,7 +18731,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18744,7 +18744,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18757,7 +18757,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18770,7 +18770,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18783,7 +18783,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18796,7 +18796,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -20276,7 +20276,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -20353,7 +20353,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -20513,29 +20513,29 @@ increased when using Strimzi on clusters where regular Kubernetes operations tak
 <p>Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>Kafka.spec.kafka.version</code> property is specified but not the <code>Kafka.spec.kafka.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as default for the init container started before the broker for initial configuration work (that is, rack support), if no image is specified as the <code>kafka-init-image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for Kafka,
 if no image is specified as the <code>Kafka.spec.kafka.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying Zookeeper, if
 no image is specified as the <code>Kafka.spec.zookeeper.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for Zookeeper, if
 no image is specified as the <code>Kafka.spec.zookeeper.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
@@ -20544,7 +20544,7 @@ no image is specified as the <code>Kafka.spec.zookeeper.tlsSidecar.image</code> 
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaConnect.spec.version</code> property is specified but not the <code>KafkaConnect.spec.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka-connect">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_CONNECT_S2I_IMAGES</code></dt>
@@ -20552,7 +20552,7 @@ This is used when a <code>KafkaConnect.spec.version</code> property is specified
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaConnectS2I.spec.version</code> property is specified but not the <code>KafkaConnectS2I.spec.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka-connect-s2i">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_MIRROR_MAKER_IMAGES</code></dt>
@@ -20560,24 +20560,24 @@ This is used when a <code>KafkaConnectS2I.spec.version</code> property is specif
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaMirrorMaker.spec.version</code> property is specified but not the <code>KafkaMirrorMaker.spec.image</code>, as described in <a href="#con-configuring-container-images-deployment-configuration-kafka-mirror-maker">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as the default when deploying the topic operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.topicOperator.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a> of the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as the default when deploying the user operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.userOperator.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a> of the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the <code>Kafka.spec.entityOperator.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
@@ -26233,7 +26233,7 @@ The format can change between Kafka releases, so messages include a version iden
 <div class="sect2">
 <h3 id="assembly-upgrade-cluster-operator-str"><a class="link" href="#assembly-upgrade-cluster-operator-str">11.3. Upgrading the Cluster Operator</a></h3>
 <div class="paragraph">
-<p>The steps to upgrade your Cluster Operator deployment to use Strimzi latest are outlined in this section.</p>
+<p>The steps to upgrade your Cluster Operator deployment to use Strimzi 0.14.0 are outlined in this section.</p>
 </div>
 <div class="paragraph">
 <p>The availability of Kafka clusters managed by the Cluster Operator is not affected by the upgrade operation.</p>
@@ -27015,7 +27015,7 @@ You must format the value of <code>log.message.format.version</code> as a string
 <p>For this release of Strimzi, resources that use the API version <code>kafka.strimzi.io/v1alpha1</code> must be updated to use <code>kafka.strimzi.io/v1beta1</code>.</p>
 </div>
 <div class="paragraph">
-<p>The <code>kafka.strimzi.io/v1alpha1</code> API version is deprecated in release latest.</p>
+<p>The <code>kafka.strimzi.io/v1alpha1</code> API version is deprecated in release 0.14.0.</p>
 </div>
 <div class="paragraph">
 <p>This section describes the upgrade steps for the resources.</p>

--- a/docs/latest/full.html
+++ b/docs/latest/full.html
@@ -1714,7 +1714,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -1791,7 +1791,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -2119,10 +2119,10 @@ You can add your own connectors by:</p>
 <div class="title">Procedure</div>
 <ol class="arabic">
 <li>
-<p>Create a new <code>Dockerfile</code> using <code>strimzi/kafka:latest-kafka-2.3.0</code> as the base image:</p>
+<p>Create a new <code>Dockerfile</code> using <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> as the base image:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code>FROM strimzi/kafka:latest-kafka-2.3.0
+<pre class="highlightjs highlight"><code>FROM strimzi/kafka:0.14.0-kafka-2.3.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -2172,7 +2172,7 @@ spec:
 <p>You can use OpenShift <a href="https://docs.okd.io/3.9/dev_guide/builds/index.html" target="_blank" rel="noopener">builds</a> and the  <a href="https://docs.okd.io/3.9/creating_images/s2i.html" target="_blank" rel="noopener">Source-to-Image (S2I)</a> framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift&#8217;s local container image repository and are available for use in deployments.</p>
 </div>
 <div class="paragraph">
-<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:latest-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
+<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
 </div>
 <div class="olist arabic">
 <div class="title">Procedure</div>
@@ -2361,7 +2361,7 @@ The Mirror Maker consumes messages from the source cluster and republishes those
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=strimzi/kafka:latest-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=strimzi/kafka:0.14.0-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
 </div>
 </div>
 </li>
@@ -2378,7 +2378,7 @@ The Mirror Maker consumes messages from the source cluster and republishes those
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=strimzi/kafka:latest-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=strimzi/kafka:0.14.0-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
 </div>
 </div>
 </li>
@@ -2697,19 +2697,19 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.1.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.1.0</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.1.1</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.1.1</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.2.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.2.0</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.2.1</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.2.1</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.3.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.3.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2741,7 +2741,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/operator:latest</p>
+<p>docker.io/strimzi/operator:0.14.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2770,7 +2770,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/kafka-bridge:latest</p>
+<p>docker.io/strimzi/kafka-bridge:0.14.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2854,7 +2854,7 @@ metadata:
 spec:
   kafka:
     replicas: 3 <b class="conum">(1)</b>
-    version: latest <b class="conum">(2)</b>
+    version: 0.14.0 <b class="conum">(2)</b>
     resources: <b class="conum">(3)</b>
       requests:
         memory: 64Gi
@@ -7450,7 +7450,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7463,7 +7463,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7476,7 +7476,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7489,7 +7489,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7502,7 +7502,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7515,7 +7515,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7528,7 +7528,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7541,7 +7541,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11603,7 +11603,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11616,7 +11616,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11629,7 +11629,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11642,7 +11642,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11655,7 +11655,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11668,7 +11668,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11681,7 +11681,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11694,7 +11694,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14547,7 +14547,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14560,7 +14560,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14573,7 +14573,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14586,7 +14586,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14599,7 +14599,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14612,7 +14612,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14625,7 +14625,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14638,7 +14638,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -15542,7 +15542,7 @@ For example:</p>
 <p>You can use OpenShift <a href="https://docs.okd.io/3.9/dev_guide/builds/index.html" target="_blank" rel="noopener">builds</a> and the  <a href="https://docs.okd.io/3.9/creating_images/s2i.html" target="_blank" rel="noopener">Source-to-Image (S2I)</a> framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift&#8217;s local container image repository and are available for use in deployments.</p>
 </div>
 <div class="paragraph">
-<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:latest-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
+<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
 </div>
 <div class="olist arabic">
 <div class="title">Procedure</div>
@@ -18705,7 +18705,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18718,7 +18718,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18731,7 +18731,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18744,7 +18744,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18757,7 +18757,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18770,7 +18770,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18783,7 +18783,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18796,7 +18796,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -20276,7 +20276,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -20353,7 +20353,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -20513,29 +20513,29 @@ increased when using Strimzi on clusters where regular Kubernetes operations tak
 <p>Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>Kafka.spec.kafka.version</code> property is specified but not the <code>Kafka.spec.kafka.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as default for the init container started before the broker for initial configuration work (that is, rack support), if no image is specified as the <code>kafka-init-image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for Kafka,
 if no image is specified as the <code>Kafka.spec.kafka.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying Zookeeper, if
 no image is specified as the <code>Kafka.spec.zookeeper.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for Zookeeper, if
 no image is specified as the <code>Kafka.spec.zookeeper.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
@@ -20544,7 +20544,7 @@ no image is specified as the <code>Kafka.spec.zookeeper.tlsSidecar.image</code> 
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaConnect.spec.version</code> property is specified but not the <code>KafkaConnect.spec.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka-connect">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_CONNECT_S2I_IMAGES</code></dt>
@@ -20552,7 +20552,7 @@ This is used when a <code>KafkaConnect.spec.version</code> property is specified
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaConnectS2I.spec.version</code> property is specified but not the <code>KafkaConnectS2I.spec.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka-connect-s2i">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_MIRROR_MAKER_IMAGES</code></dt>
@@ -20560,24 +20560,24 @@ This is used when a <code>KafkaConnectS2I.spec.version</code> property is specif
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaMirrorMaker.spec.version</code> property is specified but not the <code>KafkaMirrorMaker.spec.image</code>, as described in <a href="#con-configuring-container-images-deployment-configuration-kafka-mirror-maker">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as the default when deploying the topic operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.topicOperator.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a> of the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as the default when deploying the user operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.userOperator.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a> of the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the <code>Kafka.spec.entityOperator.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
@@ -26233,7 +26233,7 @@ The format can change between Kafka releases, so messages include a version iden
 <div class="sect2">
 <h3 id="assembly-upgrade-cluster-operator-str"><a class="link" href="#assembly-upgrade-cluster-operator-str">11.3. Upgrading the Cluster Operator</a></h3>
 <div class="paragraph">
-<p>The steps to upgrade your Cluster Operator deployment to use Strimzi latest are outlined in this section.</p>
+<p>The steps to upgrade your Cluster Operator deployment to use Strimzi 0.14.0 are outlined in this section.</p>
 </div>
 <div class="paragraph">
 <p>The availability of Kafka clusters managed by the Cluster Operator is not affected by the upgrade operation.</p>
@@ -27015,7 +27015,7 @@ You must format the value of <code>log.message.format.version</code> as a string
 <p>For this release of Strimzi, resources that use the API version <code>kafka.strimzi.io/v1alpha1</code> must be updated to use <code>kafka.strimzi.io/v1beta1</code>.</p>
 </div>
 <div class="paragraph">
-<p>The <code>kafka.strimzi.io/v1alpha1</code> API version is deprecated in release latest.</p>
+<p>The <code>kafka.strimzi.io/v1alpha1</code> API version is deprecated in release 0.14.0.</p>
 </div>
 <div class="paragraph">
 <p>This section describes the upgrade steps for the resources.</p>

--- a/docs/latest/latest.html
+++ b/docs/latest/latest.html
@@ -1277,7 +1277,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -1354,7 +1354,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -1682,10 +1682,10 @@ You can add your own connectors by:</p>
 <div class="title">Procedure</div>
 <ol class="arabic">
 <li>
-<p>Create a new <code>Dockerfile</code> using <code>strimzi/kafka:latest-kafka-2.3.0</code> as the base image:</p>
+<p>Create a new <code>Dockerfile</code> using <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> as the base image:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code>FROM strimzi/kafka:latest-kafka-2.3.0
+<pre class="highlightjs highlight"><code>FROM strimzi/kafka:0.14.0-kafka-2.3.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -1735,7 +1735,7 @@ spec:
 <p>You can use OpenShift <a href="https://docs.okd.io/3.9/dev_guide/builds/index.html" target="_blank" rel="noopener">builds</a> and the  <a href="https://docs.okd.io/3.9/creating_images/s2i.html" target="_blank" rel="noopener">Source-to-Image (S2I)</a> framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift&#8217;s local container image repository and are available for use in deployments.</p>
 </div>
 <div class="paragraph">
-<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:latest-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
+<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
 </div>
 <div class="olist arabic">
 <div class="title">Procedure</div>
@@ -1924,7 +1924,7 @@ The Mirror Maker consumes messages from the source cluster and republishes those
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=strimzi/kafka:latest-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=strimzi/kafka:0.14.0-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
 </div>
 </div>
 </li>
@@ -1941,7 +1941,7 @@ The Mirror Maker consumes messages from the source cluster and republishes those
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=strimzi/kafka:latest-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=strimzi/kafka:0.14.0-kafka-2.3.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
 </div>
 </div>
 </li>
@@ -2260,19 +2260,19 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.1.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.1.0</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.1.1</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.1.1</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.2.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.2.0</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.2.1</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.2.1</p>
 </li>
 <li>
-<p>docker.io/strimzi/kafka:latest-kafka-2.3.0</p>
+<p>docker.io/strimzi/kafka:0.14.0-kafka-2.3.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2304,7 +2304,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/operator:latest</p>
+<p>docker.io/strimzi/operator:0.14.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2333,7 +2333,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>docker.io/strimzi/kafka-bridge:latest</p>
+<p>docker.io/strimzi/kafka-bridge:0.14.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -2417,7 +2417,7 @@ metadata:
 spec:
   kafka:
     replicas: 3 <b class="conum">(1)</b>
-    version: latest <b class="conum">(2)</b>
+    version: 0.14.0 <b class="conum">(2)</b>
     resources: <b class="conum">(3)</b>
       requests:
         memory: 64Gi
@@ -7013,7 +7013,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7026,7 +7026,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7039,7 +7039,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7052,7 +7052,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7065,7 +7065,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7078,7 +7078,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7091,7 +7091,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -7104,7 +7104,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11166,7 +11166,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11179,7 +11179,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11192,7 +11192,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11205,7 +11205,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11218,7 +11218,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11231,7 +11231,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11244,7 +11244,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -11257,7 +11257,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14110,7 +14110,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14123,7 +14123,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14136,7 +14136,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14149,7 +14149,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14162,7 +14162,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14175,7 +14175,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14188,7 +14188,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -14201,7 +14201,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -15105,7 +15105,7 @@ For example:</p>
 <p>You can use OpenShift <a href="https://docs.okd.io/3.9/dev_guide/builds/index.html" target="_blank" rel="noopener">builds</a> and the  <a href="https://docs.okd.io/3.9/creating_images/s2i.html" target="_blank" rel="noopener">Source-to-Image (S2I)</a> framework to create new container images. An OpenShift build takes a builder image with S2I support, together with source code and binaries provided by the user, and uses them to build a new container image. Once built, container images are stored in OpenShift&#8217;s local container image repository and are available for use in deployments.</p>
 </div>
 <div class="paragraph">
-<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:latest-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
+<p>A Kafka Connect builder image with S2I support is provided on the <a href="https://hub.docker.com/u/strimzi" target="_blank" rel="noopener">Docker Hub</a> as part of the <code>strimzi/kafka:0.14.0-kafka-2.3.0</code> image. This S2I image takes your binaries (with plug-ins and connectors) and stores them in the <code>/tmp/kafka-plugins/s2i</code> directory. It creates a new Kafka Connect image from this directory, which can then be used with the Kafka Connect deployment. When started using the enhanced image, Kafka Connect loads any third-party plug-ins from the <code>/tmp/kafka-plugins/s2i</code> directory.</p>
 </div>
 <div class="olist arabic">
 <div class="title">Procedure</div>
@@ -18268,7 +18268,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18281,7 +18281,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18294,7 +18294,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18307,7 +18307,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18320,7 +18320,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/operator:latest</code> container image.</p>
+<p><code>strimzi/operator:0.14.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18333,7 +18333,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18346,7 +18346,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -18359,7 +18359,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>strimzi/kafka:latest-kafka-2.3.0</code> container image.</p>
+<p><code>strimzi/kafka:0.14.0-kafka-2.3.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -19839,7 +19839,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -19916,7 +19916,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:latest
+        image: strimzi/operator:0.14.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -20076,29 +20076,29 @@ increased when using Strimzi on clusters where regular Kubernetes operations tak
 <p>Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>Kafka.spec.kafka.version</code> property is specified but not the <code>Kafka.spec.kafka.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as default for the init container started before the broker for initial configuration work (that is, rack support), if no image is specified as the <code>kafka-init-image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for Kafka,
 if no image is specified as the <code>Kafka.spec.kafka.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_ZOOKEEPER_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying Zookeeper, if
 no image is specified as the <code>Kafka.spec.zookeeper.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for Zookeeper, if
 no image is specified as the <code>Kafka.spec.zookeeper.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
@@ -20107,7 +20107,7 @@ no image is specified as the <code>Kafka.spec.zookeeper.tlsSidecar.image</code> 
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaConnect.spec.version</code> property is specified but not the <code>KafkaConnect.spec.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka-connect">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_CONNECT_S2I_IMAGES</code></dt>
@@ -20115,7 +20115,7 @@ This is used when a <code>KafkaConnect.spec.version</code> property is specified
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaConnectS2I.spec.version</code> property is specified but not the <code>KafkaConnectS2I.spec.image</code>, as described in <a href="#assembly-configuring-container-images-deployment-configuration-kafka-connect-s2i">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_MIRROR_MAKER_IMAGES</code></dt>
@@ -20123,24 +20123,24 @@ This is used when a <code>KafkaConnectS2I.spec.version</code> property is specif
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.2.1=strimzi/kafka:latest-kafka-2.2.1, 2.3.0=strimzi/kafka:latest-kafka-2.3.0</code>.
+For example <code>2.2.1=strimzi/kafka:0.14.0-kafka-2.2.1, 2.3.0=strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 This is used when a <code>KafkaMirrorMaker.spec.version</code> property is specified but not the <code>KafkaMirrorMaker.spec.image</code>, as described in <a href="#con-configuring-container-images-deployment-configuration-kafka-mirror-maker">Container images</a>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as the default when deploying the topic operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.topicOperator.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a> of the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/operator:latest</code>.
+<p>Optional, default <code>strimzi/operator:0.14.0</code>.
 The image name to use as the default when deploying the user operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.userOperator.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a> of the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>strimzi/kafka:latest-kafka-2.3.0</code>.
+<p>Optional, default <code>strimzi/kafka:0.14.0-kafka-2.3.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the <code>Kafka.spec.entityOperator.tlsSidecar.image</code> in the <a href="#assembly-configuring-container-images-deployment-configuration-kafka">Container images</a>.</p>
 </dd>
@@ -25796,7 +25796,7 @@ The format can change between Kafka releases, so messages include a version iden
 <div class="sect2">
 <h3 id="assembly-upgrade-cluster-operator-str"><a class="link" href="#assembly-upgrade-cluster-operator-str">11.3. Upgrading the Cluster Operator</a></h3>
 <div class="paragraph">
-<p>The steps to upgrade your Cluster Operator deployment to use Strimzi latest are outlined in this section.</p>
+<p>The steps to upgrade your Cluster Operator deployment to use Strimzi 0.14.0 are outlined in this section.</p>
 </div>
 <div class="paragraph">
 <p>The availability of Kafka clusters managed by the Cluster Operator is not affected by the upgrade operation.</p>
@@ -26578,7 +26578,7 @@ You must format the value of <code>log.message.format.version</code> as a string
 <p>For this release of Strimzi, resources that use the API version <code>kafka.strimzi.io/v1alpha1</code> must be updated to use <code>kafka.strimzi.io/v1beta1</code>.</p>
 </div>
 <div class="paragraph">
-<p>The <code>kafka.strimzi.io/v1alpha1</code> API version is deprecated in release latest.</p>
+<p>The <code>kafka.strimzi.io/v1alpha1</code> API version is deprecated in release 0.14.0.</p>
 </div>
 <div class="paragraph">
 <p>This section describes the upgrade steps for the resources.</p>


### PR DESCRIPTION
It seems that due to some misprocessing our 0.14.0 docs refer to the latest version on many places. This PR should fix it. This was probably uman error and not system issue with the build system.