### PR TITLE
Use Netlify redirects to create a simple URL to our installation files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,9 @@ url: "https://strimzi.io" # the base hostname & protocol for your site, e.g. htt
 twitter_username: strimziio
 github_username:  strimzi
 
+# _redirects file for Netlify should be included
+include: ["_redirects"]
+
 # Build settings
 markdown: kramdown
 theme: minima

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+# Redirects to the latest all-in-one install file
+/install    https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-cluster-operator-0.14.0.yaml     200

--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,2 @@
 # Redirects to the latest all-in-one install file
-/install    https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-cluster-operator-0.14.0.yaml     200
+/install/latest    https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-cluster-operator-0.14.0.yaml     200


### PR DESCRIPTION
Use Netlify redirects to create a simple URL to our installation files - somthing like `https://strimzi.io/install` to redirect to the single YAML installation.