### PR TITLE
Fix documentation archive to support multiple books

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -1,37 +1,112 @@
 operator:
   - version: 0.16.0
     defaultKafkaVersion: 2.4.0
+    overview_book: true
+    quickstart_book: true
+    using_book: true
   - version: 0.15.0
     defaultKafkaVersion: 2.3.1
+    overview_book: false
+    quickstart_book: true
+    using_book: true
   - version: 0.14.0
     defaultKafkaVersion: 2.3.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.13.0
     defaultKafkaVersion: 2.3.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.12.2
     defaultKafkaVersion: 2.2.1
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.12.1
     defaultKafkaVersion: 2.2.1
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.12.0
     defaultKafkaVersion: 2.2.1
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.11.4
     defaultKafkaVersion: 2.1.1
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.11.3
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.11.2
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.11.1
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.11.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.10.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.9.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.8.2
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.8.1
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.8.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.7.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.6.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.5.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.4.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.3.1
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.3.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.2.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
   - version: 0.1.0
+    overview_book: false
+    quickstart_book: false
+    using_book: true
 bridge:
   - version: 0.15.0
   - version: 0.14.0

--- a/documentation/archive/index.md
+++ b/documentation/archive/index.md
@@ -9,20 +9,18 @@ layout: default
 {% for item in site.data.releases.operator -%}
 ### {{item.version}}
 
-{% if item.overview_book == "true" -%}
+{% if item.overview_book == true -%}
 * [Overview Guide](/docs/overview/{{item.version}}/)
 {% endif -%}
 
-{% if item.quickstart_book == "true" -%}
+{% if item.quickstart_book == true -%}
 * [Quick Start Guide](/docs/quickstart/{{item.version}}/)
 {% endif -%}
 
-{% if item.using_book == "true" -%}
-{% if item.version != "0.1.0" -%}
+{% if item.using_book == true and item.version != "0.1.0" -%}
 * [Using Strimzi](/docs/{{item.version}}/)
 {% else -%}
 * [Using Strimzi](/docs/0.1.0/README.md)
-{% endif -%}
 {% endif -%}
 
 {% endfor -%}

--- a/documentation/archive/index.md
+++ b/documentation/archive/index.md
@@ -7,6 +7,7 @@ layout: default
 ## Strimzi Kafka operators
 
 {% for item in site.data.releases.operator -%}
+
 ### {{item.version}}
 
 {% if item.overview_book == true -%}
@@ -19,12 +20,13 @@ layout: default
 
 {% if item.using_book == true and item.version != "0.1.0" -%}
 * [Using Strimzi](/docs/{{item.version}}/)
+
 {% else -%}
 * [Using Strimzi](/docs/0.1.0/README.md)
+
 {% endif -%}
 
 {% endfor -%}
-
 
 ## Strimzi Kafka bridge
 

--- a/documentation/archive/index.md
+++ b/documentation/archive/index.md
@@ -7,13 +7,25 @@ layout: default
 ## Strimzi Kafka operators
 
 {% for item in site.data.releases.operator -%}
-{% if item.version != "0.1.0" -%}
-* [{{item.version}}](/docs/{{item.version}}/)
-{% else -%}
-* [0.1.0](/docs/0.1.0/README.md)
-{% endif -%}
-{% endfor -%}
+### {{item.version}}
 
+{% if item.overview_book == "true" -%}
+* [Overview Guide](/docs/overview/{{item.version}}/)
+{% endif -%}
+
+{% if item.quickstart_book == "true" -%}
+* [Quick Start Guide](/docs/quickstart/{{item.version}}/)
+{% endif -%}
+
+{% if item.using_book == "true" -%}
+{% if item.version != "0.1.0" -%}
+* [Using Strimzi](/docs/{{item.version}}/)
+{% else -%}
+* [Using Strimzi](/docs/0.1.0/README.md)
+{% endif -%}
+{% endif -%}
+
+{% endfor -%}
 
 
 ## Strimzi Kafka bridge


### PR DESCRIPTION
The documentation archive doesnt currently contain links to the new Overview and Quick Start books added in new releases. This Pr tries to fix that.