### PR TITLE
Fix typo in HTTP Bridge blog post

### DIFF
--- a/_posts/2019-11-05-exposing-http-bridge.md
+++ b/_posts/2019-11-05-exposing-http-bridge.md
@@ -98,7 +98,7 @@ Following an example of the output.
 
 # Producing messages
 
-Assuming that the Kafka brokers have topic auto creation enabled, we can start immediately to send messages through the `/topic/{topicname}` endpoint exposed by the HTTP bridge.
+Assuming that the Kafka brokers have topic auto creation enabled, we can start immediately to send messages through the `/topics/{topicname}` endpoint exposed by the HTTP bridge.
 
 The HTTP request payload is always a JSON but the message values can be JSON or binary (encoded in base64 because you are sending binary data in a JSON payload so encoding in a string format is needed).
 


### PR DESCRIPTION
This PR fixes the typo in the HTTP Bridge blog post which was reported on Slack (https://cloud-native.slack.com/archives/CMH3Q3SNP/p1581290373448700)