### PR TITLE
Fix typo in redirect file

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,2 @@
 # Redirects to the latest all-in-one install file
-/install/latest    https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.16.2/strimzi-cluster-operator-0.16.1.yaml     200
+/install/latest    https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.16.2/strimzi-cluster-operator-0.16.2.yaml     200


### PR DESCRIPTION
The redirect to the latst installation file has a typo in it and doesn't work. This PR fixes it.