### PR TITLE
Add redirects for old blog post URLs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,6 @@
 # Redirects to the latest all-in-one install file
-/install/latest    https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.17.0/strimzi-cluster-operator-0.17.0.yaml     200
-/examples/latest/*    https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.17.0/examples/:splat                          200
+/install/latest             https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.17.0/strimzi-cluster-operator-0.17.0.yaml     200
+/examples/latest/*          https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.17.0/examples/:splat                             200
+/2018/:month/:date/:slug    /blog/2018/:month/:date/:slug                                                                                       301
+/2019/:month/:date/:slug    /blog/2019/:month/:date/:slug                                                                                       301
+/2020/:month/:date/:slug    /blog/2020/:month/:date/:slug                                                                                       301


### PR DESCRIPTION
The URLs of the blog posts changed on the new website. This Pr tries to add redirects to make sure the old URLS forward to the new ones.