### PR TITLE
Change the KubeCon banner to Europe and not to North America

### DIFF
--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -22,12 +22,12 @@
     <div class="width-7-12 width-12-12-m align-self-center">
       <p class="text-centered margin-tb-0">
         Join us at<br/>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" target="_blank">KubeCon + CloudNativeCon : North America 2020</a><br/>
-        Boston, Massachusetts : November 17-20
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" target="_blank">KubeCon + CloudNativeCon: Europe 2020</a><br/>
+        Amsterdam, The Netherlands: August 13-16
       </p>
     </div>
     <div class="width-5-12 width-12-12-m align-self-center">
-      <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" target="_blank">
+      <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" target="_blank">
         <img src="{{site.baseurl}}/assets/images/kubecon_cloudnative_logos.png">
       </a>
     </div>


### PR DESCRIPTION
The KubeCon banner currently points to KubeCon NA. We should have it pointing to KubeCon Europe which will be first.