### PR TITLE
Add redirects for Quick Starts guides

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -10,3 +10,5 @@
 /docs/overview/master/              /docs/operators/master/overview.html                                                                                301
 /docs/quickstart/master/            /docs/operators/master/quickstart.html                                                                              301
 /docs/master/                       /docs/operators/master/using.html                                                                                   301
+/quickstarts/minikube               /quickstarts/                                                                                                       301
+/quickstarts/okd                    /quickstarts/                                                                                                       301


### PR DESCRIPTION
This adds redirects to the old Quick Starts links which might be still somewhere listed. Related to strimzi/strimzi-kafka-operator#2889