### PR TITLE
Make it clear in the latest docs wfor which version they apply

### DIFF
--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -1,5 +1,5 @@
 <head>
-  <title>{{ page.title }}</title>
+  <title>{{ page.title | replace: '!LATEST_OPERATOR_VERSION!', site.data.releases.operator[0].version | replace: '!LATEST_BRIDGE_VERSION!', site.data.releases.bridge[0].version }}</title>
   <script id="adobe_dtm" src="//www.redhat.com/dtm.js" type="text/javascript"></script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
   <div class="site-content">
     <div class="grid-wrapper">
       <div class="grid__item width-12-12">
-        <h1>{{ page.title }}</h1>
+        <h1>{{ page.title | replace: '!LATEST_OPERATOR_VERSION!', site.data.releases.operator[0].version | replace: '!LATEST_BRIDGE_VERSION!', site.data.releases.bridge[0].version }}</h1>
       </div>
       <div class="grid__item width-8-12 toc-content">
         {{ content }}

--- a/docs/bridge/latest/index.md
+++ b/docs/bridge/latest/index.md
@@ -1,8 +1,6 @@
 ---
-title: Strimzi Kafka Bridge Documentation ({{site.data.releases.bridge[0].version}})
+title: Strimzi Kafka Bridge Documentation (!LATEST_BRIDGE_VERSION!)
 layout: default
 ---
-
-<h1>Strimzi Kafka Bridge Documentation ({{site.data.releases.bridge[0].version}})</h1>
 
 {% include_relative latest.html %}

--- a/docs/bridge/latest/index.md
+++ b/docs/bridge/latest/index.md
@@ -1,8 +1,8 @@
 ---
-title: Strimzi Kafka Bridge Documentation (Latest)
+title: Strimzi Kafka Bridge Documentation ({{site.data.releases.bridge[0].version}})
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (Latest)</h1>
+<h1>Strimzi Kafka Bridge Documentation ({{site.data.releases.bridge[0].version}})</h1>
 
 {% include_relative latest.html %}

--- a/docs/latest/index.md
+++ b/docs/latest/index.md
@@ -1,8 +1,8 @@
 ---
-title: Using Strimzi (Latest)
+title: Using Strimzi ({{site.data.releases.operator[0].version}})
 layout: default
 ---
 
-<h1>Using Strimzi (Latest)</h1>
+<h1>Using Strimzi ({{site.data.releases.operator[0].version}})</h1>
 
 {% include_relative latest.html %}

--- a/docs/latest/index.md
+++ b/docs/latest/index.md
@@ -1,8 +1,6 @@
 ---
-title: Using Strimzi ({{site.data.releases.operator[0].version}})
+title: Using Strimzi (!LATEST_OPERATOR_VERSION!)
 layout: default
 ---
-
-<h1>Using Strimzi ({{site.data.releases.operator[0].version}})</h1>
 
 {% include_relative latest.html %}

--- a/docs/overview/latest/index.md
+++ b/docs/overview/latest/index.md
@@ -1,8 +1,6 @@
 ---
-title: Strimzi Overview ({{site.data.releases.operator[0].version}})
+title: Strimzi Overview (!LATEST_OPERATOR_VERSION!)
 layout: default
 ---
-
-<h1>Strimzi Overview ({{site.data.releases.operator[0].version}})</h1>
 
 {% include_relative latest.html %}

--- a/docs/overview/latest/index.md
+++ b/docs/overview/latest/index.md
@@ -1,8 +1,8 @@
 ---
-title: Strimzi Overview (Latest stable version)
+title: Strimzi Overview ({{site.data.releases.operator[0].version}})
 layout: default
 ---
 
-<h1>Strimzi Overview (Latest stable version)</h1>
+<h1>Strimzi Overview ({{site.data.releases.operator[0].version}})</h1>
 
 {% include_relative latest.html %}

--- a/docs/quickstart/latest/index.md
+++ b/docs/quickstart/latest/index.md
@@ -1,8 +1,8 @@
 ---
-title: Strimzi Quick Start Guide (Latest stable)
+title: Strimzi Quick Start Guide ({{site.data.releases.operator[0].version}})
 layout: default
 ---
 
-<h1>Strimzi Quick Start Guide (Latest stable)</h1>
+<h1>Strimzi Quick Start Guide ({{site.data.releases.operator[0].version}})</h1>
 
 {% include_relative latest.html %}

--- a/docs/quickstart/latest/index.md
+++ b/docs/quickstart/latest/index.md
@@ -1,8 +1,6 @@
 ---
-title: Strimzi Quick Start Guide ({{site.data.releases.operator[0].version}})
+title: Strimzi Quick Start Guide (!LATEST_OPERATOR_VERSION!)
 layout: default
 ---
-
-<h1>Strimzi Quick Start Guide ({{site.data.releases.operator[0].version}})</h1>
 
 {% include_relative latest.html %}


### PR DESCRIPTION
Currently, in the latest docs, we do not say for whcih version they apply. we just say _Latest_ or _Latest stable_. That could be confusing - while we know which version is the latest, the users might not. This PR replaces the _latest_ with the actual version number to mke it easier for users.