### PR TITLE
Remove docker ps command in the kind quickstart

### DIFF
--- a/quickstarts/kind.md
+++ b/quickstarts/kind.md
@@ -21,7 +21,6 @@ Once you have all the binaries installed, and a Docker daemon running, make sure
 
 ```shell
 # Validate docker installation
-docker ps
 docker version
 
 # Validate kind


### PR DESCRIPTION
This PR removes the `docker ps` command for validating Docker installation in the Quickstart with Kind. I don't see any value in using it. I think that `docker version` is enough which provides the error if you don't have the rights to use docker and if, for example, the docker daemon is not running.