### PR TITLE
Move the project roadmap

### DIFF
--- a/_includes/homepage/homepage-content-band.html
+++ b/_includes/homepage/homepage-content-band.html
@@ -33,7 +33,7 @@
         <p>
           <strong class="text-caps">Project Roadmap</strong>
           <br/>
-          Learn about the future plans for the project by viewing the <a href="https://github.com/strimzi/strimzi-kafka-operator/projects/1">roadmap</a>.
+          Learn about the future plans for the project by viewing the <a href="https://github.com/orgs/strimzi/projects/1">roadmap</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
As per https://github.com/strimzi/strimzi-kafka-operator/blob/master/design/github-repository-restructuring.md., the project roadmap is now moved from a GitHub project in the strimzi-kafka-operators repository to the Stirmzi GitHUb organization: https://github.com/orgs/strimzi/projects/1

This PR changes the link to the roadmap on the website to make it in sync.