### PR TITLE
Update KubeCon date and location

### DIFF
--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -24,7 +24,7 @@
       <p class="text-centered margin-tb-0">
         Join us at<br/>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" target="_blank">KubeCon + CloudNativeCon: Europe 2020</a><br/>
-        Amsterdam, The Netherlands: August 13-16
+        Virtual: August 17-20
       </p>
     </div>
     <div class="width-5-12 width-12-12-m align-self-center">


### PR DESCRIPTION
The KubeCon banner on the website has old date and wrong location. This PR fixes it.