### PR TITLE
Remove the KubeCon EU band and improve the used-by section

### DIFF
--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -5,13 +5,19 @@
     </div>
 
     <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/helvetia_logo.png"></div>
-    <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/lightbend_logo.png"></div>
     <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/redhat_logo.png"></div>
-    <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/axual_logo.png"></div>
-    <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/grupomasmovil_logo.png"></div>
-    <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/sbb_logo.svg"></div>
-    <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/marlow-logo.svg"></div>
+    <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/lightbend_logo.png"></div>
+
     <div class="width-2-12 width-12-12-m"></div>
+    <div class="width-4-12 width-12-12-m margin-tb-xl logo-img"><img src="{{site.baseurl}}/assets/images/grupomasmovil_logo.png"></div>
+    <div class="width-4-12 width-12-12-m margin-tb-xl logo-img"><img src="{{site.baseurl}}/assets/images/sbb_logo.svg"></div>
+    <div class="width-2-12 width-12-12-m"></div>
+
+    <div class="width-3-12 width-12-12-m"></div>
+    <div class="width-3-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/axual_logo.png"></div>
+    <div class="width-3-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/marlow-logo.svg"></div>
+    <div class="width-3-12 width-12-12-m"></div>
+    
   </div>
   <div class="grid-wrapper margin-tb-xl">
     <div class="width-5-12 width-12-12-m cloud-native">
@@ -23,7 +29,7 @@
       <p class="margin-tb-0">We are a <a href="https://cncf.io/" target="_blank">Cloud Native Computing Foundation</a> sandbox project.</p>
     </div>
   </div>
-  <div class="grid-wrapper">
+  <!--<div class="grid-wrapper">
     <div class="width-7-12 width-12-12-m align-self-center">
       <p class="text-centered margin-tb-0">
         Join us at<br/>
@@ -36,5 +42,5 @@
         <img src="{{site.baseurl}}/assets/images/kubecon_cloudnative_logos.png">
       </a>
     </div>
-  </div>
+  </div>-->
 </div>


### PR DESCRIPTION
This PR removes the KubeCon EU 2020 band from the website (it is just commented out so that we can easily re-use it later). It also improves the distribution of logos in the _Used by_ section to better fit with regards to size of the logos etc. 