### PR TITLE
Fixed authors on latest blog posts

### DIFF
--- a/_posts/2020-09-29-strimzi-survey-results.md
+++ b/_posts/2020-09-29-strimzi-survey-results.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Insights from the first Strimzi survey"
 date: 2020-09-29
-author: tombentley
+author: tom_bentley
 ---
 
 In August, with the help of the CNCF, we ran a survey of the Strimzi community. 

--- a/_posts/2020-10-01-hacktoberfest.md
+++ b/_posts/2020-10-01-hacktoberfest.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Hacktoberfest: let's start to contribute to Strimzi"
 date: 2020-10-01
-author: ppatierno
+author: paolo_patierno
 ---
 
 Finally, it is October and it is time for [Hacktoberfest](https://hacktoberfest.digitalocean.com/)!


### PR DESCRIPTION
Just noticed that the latest two blog posts don't show authors names because of the wrong id related to the authors YAML file.