### PR TITLE
Links to examples; signpost where next after quickstart

### DIFF
--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -10,7 +10,8 @@
         Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
         Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
         Deploying Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
-        Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a>
+        Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
+        Example custom resources: <a href="{{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples">{{site.data.releases.operator[0].version}} - latest stable release</a>
       </p>
       <p>
         <strong class="text-caps">Strimzi Kafka Bridge Documentation</strong>

--- a/quickstarts/kind.md
+++ b/quickstarts/kind.md
@@ -106,3 +106,9 @@ kubectl -n kafka run kafka-consumer -ti --image=strimzi/kafka:{{site.data.releas
 ```
 
 Enjoy your Apache Kafka cluster, running on Kind!
+
+# Where next?
+
+* If that was a little too quick, you might prefer a more [descriptive introduction to Strimzi](/docs/operators/latest/quickstart.html), covering the same ground but with more explanation.
+* For an overview of the Strimzi components check out the [overview guide](/docs/operators/latest/overview.html).
+* For alternative examples of the custom resource which defines the Kafka cluster have a look at these [examples]({{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples/kafka)

--- a/quickstarts/minikube.md
+++ b/quickstarts/minikube.md
@@ -24,7 +24,7 @@ kubectl apply -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
 
 # Provision the Apache Kafka cluster
 
-After that we feed Strimzi with a simple **Custom Resource**, which will then give you a small persistent Apache Kafka Cluster with one node for each, Apache Zookeeper and Apache Kafka:
+After that we feed Strimzi with a simple **Custom Resource**, which will then give you a small persistent Apache Kafka Cluster with one node each for Apache Zookeeper and Apache Kafka:
 
 ```shell
 # Apply the `Kafka` Cluster CR file
@@ -54,3 +54,9 @@ kubectl -n kafka run kafka-consumer -ti --image=strimzi/kafka:{{site.data.releas
 ```
 
 Enjoy your Apache Kafka cluster, running on Minikube!
+
+# Where next?
+
+* If that was a little too quick, you might prefer a more [descriptive introduction to Strimzi](/docs/operators/latest/quickstart.html), covering the same ground but with more explanation.
+* For an overview of the Strimzi components check out the [overview guide](/docs/operators/latest/overview.html).
+* For alternative examples of the custom resource which defines the Kafka cluster have a look at these [examples]({{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples/kafka)

--- a/quickstarts/okd.md
+++ b/quickstarts/okd.md
@@ -53,3 +53,9 @@ oc -n myproject run kafka-consumer -ti --image=strimzi/kafka:{{site.data.release
 ```
 
 Enjoy your Apache Kafka cluster, running on OKD!
+
+# Where next?
+
+* If that was a little too quick, you might prefer a more [descriptive introduction to Strimzi](/docs/operators/latest/quickstart.html), covering the same ground but with more explanation.
+* For an overview of the Strimzi components check out the [overview guide](/docs/operators/latest/overview.html).
+* For alternative examples of the custom resource which defines the Kafka cluster have a look at these [examples]({{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples/kafka)


### PR DESCRIPTION
This PR does two things, based on some of the feedback from the survey:

1. It explicitly gives people some suggested things to read next at the end of the quickstart.
2. It adds a link to the custom resource examples to the documentation page.

Signed-off-by: Tom Bentley <tbentley@redhat.com>