### PR TITLE
Add style to remove extra white space on tablet and mobile screens

### DIFF
--- a/_sass/strimzi.scss
+++ b/_sass/strimzi.scss
@@ -13,7 +13,7 @@ body {
   line-height: 1.5rem;
 }
 
-body:not(.homepage){
+body:not(.homepage) {
   div.site-content {
     padding-bottom: 6rem;
   }
@@ -68,7 +68,7 @@ h4 {
   color: #2A5D6C;
   @media screen and (max-width: 768px) {
     font-size: 1.125rem;
-    line-height: 1.5rem;    
+    line-height: 1.5rem;
   }
 }
 
@@ -130,6 +130,7 @@ code {
   background-color: #F0F0F0;
   padding: 0 5px;
   color: inherit;
+  overflow-wrap: break-word;
 }
 
 p code,
@@ -182,7 +183,7 @@ table {
   }
 }
 
-blockquote{
+blockquote {
   width: 80%;
   margin: 2rem auto;
   font-style: italic;
@@ -197,16 +198,16 @@ blockquote{
   }
 }
 
-blockquote::before{
+blockquote::before {
   content: "\201C";
   color: $blue;
-  font-size:4em;
+  font-size: 4em;
   position: absolute;
   left: 10px;
-  top:-10px;
+  top: -10px;
 }
 
-blockquote::after{
+blockquote::after {
   content: '';
 }
 
@@ -239,10 +240,25 @@ blockquote::after{
 }
 
 .gradient-bg {
-  background: rgb(24,44,70);
-  background: -moz-linear-gradient(145deg, rgba(24,44,70,1) 0%, rgba(39,81,108,1) 50%, rgba(83,185,215,1) 100%);
-  background: -webkit-linear-gradient(145deg, rgba(24,44,70,1) 0%, rgba(39,81,108,1) 50%, rgba(83,185,215,1) 100%);
-  background: linear-gradient(145deg, rgba(24,44,70,1) 0%, rgba(39,81,108,1) 50%, rgba(83,185,215,1) 100%);
+  background: rgb(24, 44, 70);
+  background: -moz-linear-gradient(
+    145deg,
+    rgba(24, 44, 70, 1) 0%,
+    rgba(39, 81, 108, 1) 50%,
+    rgba(83, 185, 215, 1) 100%
+  );
+  background: -webkit-linear-gradient(
+    145deg,
+    rgba(24, 44, 70, 1) 0%,
+    rgba(39, 81, 108, 1) 50%,
+    rgba(83, 185, 215, 1) 100%
+  );
+  background: linear-gradient(
+    145deg,
+    rgba(24, 44, 70, 1) 0%,
+    rgba(39, 81, 108, 1) 50%,
+    rgba(83, 185, 215, 1) 100%
+  );
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#182c46",endColorstr="#53b9d7",GradientType=1);
 }
 
@@ -460,7 +476,7 @@ blockquote::after{
 .paragraph > .title {
   font-size: 1.3rem;
   text-align: left;
-  margin-bottom: 12px; 
+  margin-bottom: 12px;
 }
 
 .announcement_blue, .announcement_orange {
@@ -468,25 +484,24 @@ blockquote::after{
   padding: 2rem 13rem;
 
   p {
-  font-size: 1.5rem;
-  line-height: 1.75rem;
-  text-align: center;
-  margin: .5rem;
-  color: $black;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+    text-align: center;
+    margin: .5rem;
+    color: $black;
   }
 
-  a{
-  color: $black !important;
+  a {
+    color: $black !important;
   }
 }
 
 .announcement_blue {
-background-color: $light-blue;
+  background-color: $light-blue;
 }
 .announcement_orange {
-background-color: $orange;
+  background-color: $orange;
 }
-
 
 /* Zoom band */
 
@@ -495,15 +510,25 @@ background-color: $orange;
   margin: 0 -13rem;
   padding: 2rem 13rem;
 
+  @media screen and (max-width: 1170px) {
+    margin: 0 -6rem;
+    padding: 2rem 6rem;
+  }
+
+  @media screen and (max-width: 768px) {
+    margin: 0 -2rem;
+    padding: 2rem;
+  }
+
   p {
-  font-size: 1.5rem;
-  line-height: 1.75rem;
-  margin: .5rem;
-  color: $black;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+    margin: .5rem;
+    color: $black;
   }
 
   img {
-  max-width: 150px;
-  float: right;
+    max-width: 150px;
+    float: right;
   }
 }


### PR DESCRIPTION
On the main page, I found out that the `zoom_band` section is not handled on mobile and tablet screens properly. The fix on the main page is in adding extra media queries in the section.

On blog post pages the long string wrapped in the `code` tag is not split which causes that the issue. Adding a CSS style of `break-word` fixes the issue there.

<img width="505" alt="Screenshot 2020-11-04 at 09 11 03" src="https://user-images.githubusercontent.com/1914165/98097092-6a210f80-1e84-11eb-94a8-1ca68d27d0d0.png">

I also updated a bit of styling in the `_sass/strimzi.scss` file.

Closes #190 