### PR TITLE
Rename Deploying guide to Deploying and Upgrading

### DIFF
--- a/_includes/documentation/documentation-archive-band.html
+++ b/_includes/documentation/documentation-archive-band.html
@@ -15,7 +15,7 @@
           <ul>
             {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/overview.html">Overview guide</a></li>{% endif %}
             {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/quickstart.html">Quick Start guide</a></li>{% endif %}
-            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying Strimzi</a></li>{% endif %}
+            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying and Upgrading Strimzi</a></li>{% endif %}
             {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/using.html">Using Strimzi</a></li>{% endif %}
           </ul>
         {% elsif oRelease.directory_layout == "layout1" %}

--- a/_includes/documentation/documentation-archive-band.html
+++ b/_includes/documentation/documentation-archive-band.html
@@ -15,7 +15,7 @@
           <ul>
             {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/overview.html">Overview guide</a></li>{% endif %}
             {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/quickstart.html">Quick Start guide</a></li>{% endif %}
-            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying and Upgrading Strimzi</a></li>{% endif %}
+            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying and Upgrading</a></li>{% endif %}
             {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/using.html">Using Strimzi</a></li>{% endif %}
           </ul>
         {% elsif oRelease.directory_layout == "layout1" %}

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -9,10 +9,10 @@
         <br/>
         Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
         Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
-        Deploying Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
+        Deploying and Upgrading Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
         Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
         Example custom resources: <a href="{{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples">{{site.data.releases.operator[0].version}} - latest stable release</a>
-      </p>
+      </p><br/>
       <p>
         <strong class="text-caps">Strimzi Kafka Bridge Documentation</strong>
         <br/>
@@ -29,8 +29,9 @@
         Strimzi Kafka operators Master<br>
         <a href="{{site.baseurl}}/docs/operators/master/overview.html">Overview guide</a> |
         <a href="{{site.baseurl}}/docs/operators/master/quickstart.html">Quick Start guide</a> |
-        <a href="{{site.baseurl}}/docs/operators/master/deploying.html">Deploying Strimzi</a> |
-        <a href="{{site.baseurl}}/docs/operators/master/using.html">Using Strimzi</a>
+        <a href="{{site.baseurl}}/docs/operators/master/deploying.html">Deploying and Upgrading Strimzi</a> |<br/>
+        <a href="{{site.baseurl}}/docs/operators/master/using.html">Using Strimzi</a> | 
+        <a href="{{site.github_url}}/strimzi-kafka-operator/tree/master/examples">Example custom resources</a>
       </p>
       <p>Strimzi Kafka Bridge: <a href="{{site.baseurl}}/docs/bridge/master/">Master</a></p>
     </div>

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -9,7 +9,7 @@
         <br/>
         Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
         Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
-        Deploying and Upgrading Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
+        Deploying and Upgrading: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
         Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
         Example custom resources: <a href="{{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples">{{site.data.releases.operator[0].version}} - latest stable release</a>
       </p><br/>
@@ -29,7 +29,7 @@
         Strimzi Kafka operators Master<br>
         <a href="{{site.baseurl}}/docs/operators/master/overview.html">Overview guide</a> |
         <a href="{{site.baseurl}}/docs/operators/master/quickstart.html">Quick Start guide</a> |
-        <a href="{{site.baseurl}}/docs/operators/master/deploying.html">Deploying and Upgrading Strimzi</a> |<br/>
+        <a href="{{site.baseurl}}/docs/operators/master/deploying.html">Deploying and Upgrading</a> |<br/>
         <a href="{{site.baseurl}}/docs/operators/master/using.html">Using Strimzi</a> | 
         <a href="{{site.github_url}}/strimzi-kafka-operator/tree/master/examples">Example custom resources</a>
       </p>

--- a/docs/operators/0.18.0/deploying.md
+++ b/docs/operators/0.18.0/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying Strimzi (0.18.0)
+title: Deploying and Upgrading Strimzi (0.18.0)
 layout: default
 ---
 

--- a/docs/operators/0.18.0/deploying.md
+++ b/docs/operators/0.18.0/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying and Upgrading Strimzi (0.18.0)
+title: Deploying and Upgrading (0.18.0)
 layout: default
 ---
 

--- a/docs/operators/0.19.0/deploying.md
+++ b/docs/operators/0.19.0/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying Strimzi (0.19.0)
+title: Deploying and Upgrading (0.19.0)
 layout: default
 ---
 

--- a/docs/operators/0.20.0/deploying.md
+++ b/docs/operators/0.20.0/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying and Upgrading Strimzi (0.20.0)
+title: Deploying and Upgrading (0.20.0)
 layout: default
 ---
 

--- a/docs/operators/0.20.0/deploying.md
+++ b/docs/operators/0.20.0/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying Strimzi (0.20.0)
+title: Deploying and Upgrading Strimzi (0.20.0)
 layout: default
 ---
 

--- a/docs/operators/latest/deploying.md
+++ b/docs/operators/latest/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying Strimzi (!LATEST_OPERATOR_VERSION!)
+title: Deploying and Upgrading Strimzi (!LATEST_OPERATOR_VERSION!)
 layout: default
 ---
 

--- a/docs/operators/latest/deploying.md
+++ b/docs/operators/latest/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying and Upgrading Strimzi (!LATEST_OPERATOR_VERSION!)
+title: Deploying and Upgrading (!LATEST_OPERATOR_VERSION!)
 layout: default
 ---
 

--- a/docs/operators/master/deploying.md
+++ b/docs/operators/master/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying Strimzi (Master)
+title: Deploying and Upgrading Strimzi (Master)
 layout: default
 ---
 

--- a/docs/operators/master/deploying.md
+++ b/docs/operators/master/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying and Upgrading Strimzi (Master)
+title: Deploying and Upgrading (Master)
 layout: default
 ---
 


### PR DESCRIPTION
The _Deploying_ guide also contains the upgrade documentation. Therefore @PaulRMellor suggested to call it _Deploying and Upgrading_ guide to make it easier for users to find the upgrade docs. This PR renames the docs on our website to match that.