### PR TITLE
Fix indentation in logging BP

### DIFF
--- a/_posts/2020-11-10-dynamically-changeable-logging.md
+++ b/_posts/2020-11-10-dynamically-changeable-logging.md
@@ -70,21 +70,19 @@ The logging is still configurable through the `inline` or `external` logging sec
 Example of `inline` logging.
 ```yaml
 ...
-spec:
-  logging:
-    type: inline
-    loggers:
-      kafka.root.logger.level = INFO
+logging:
+  type: inline
+  loggers:
+    kafka.root.logger.level = INFO
 ...
 ```
 
 Example of external logging.
 ```yaml
 ...
-spec:
-  logging:
-    type: external
-    name: my-external-config-map
+logging:
+  type: external
+  name: my-external-config-map
 ...
 ```
 

--- a/_posts/2020-11-10-dynamically-changeable-logging.md
+++ b/_posts/2020-11-10-dynamically-changeable-logging.md
@@ -73,8 +73,8 @@ Example of `inline` logging.
 spec:
   logging:
     type: inline
-      loggers:
-        kafka.root.logger.level = INFO
+    loggers:
+      kafka.root.logger.level = INFO
 ...
 ```
 
@@ -84,7 +84,7 @@ Example of external logging.
 spec:
   logging:
     type: external
-      name: my-external-config-map
+    name: my-external-config-map
 ...
 ```
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

I am sorry. There is an indentation error in the Dynamic logging blogpost.