### PR TITLE
Fix download links for Helm Charts

### DIFF
--- a/_includes/downloads/downloads-release-band.html
+++ b/_includes/downloads/downloads-release-band.html
@@ -30,10 +30,17 @@
             </td>
           </tr>
           <tr>
-            <td class="description">strimzi-kafka-operator-helm-chart-{{oRelease}}</td>
+            <td class="description">strimzi-kafka-operator-helm-2-chart-0.20.0</td>
             <td class="licence">AL 2.0</td>
             <td class="links">
-              <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{oRelease}}/strimzi-kafka-operator-helm-chart-{{oRelease}}.tgz">tgz</a>
+              <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{oRelease}}/strimzi-kafka-operator-helm-2-chart-{{oRelease}}.tgz">tgz</a>
+            </td>
+          </tr>
+          <tr>
+            <td class="description">strimzi-kafka-operator-helm-3-chart-0.20.0</td>
+            <td class="licence">AL 2.0</td>
+            <td class="links">
+              <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{oRelease}}/strimzi-kafka-operator-helm-3-chart-{{oRelease}}.tgz">tgz</a>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
This PR fixes the broken download links in for Helm Charts in the Downloads section.