### PR TITLE
Add new section to Download page with supported versions of the different components

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -1,6 +1,10 @@
 operator:
   - version: 0.20.0
     defaultKafkaVersion: 2.6.0
+    bridgeVersion: 0.19.0
+    oAuthVersion: 0.6.1
+    kafkaVersions: 2.5.0, 2.5.1, 2.6.0
+    kubernetesVersions: 1.11+
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -8,6 +12,10 @@ operator:
     directory_layout: layout2
   - version: 0.19.0
     defaultKafkaVersion: 2.5.0
+    bridgeVersion: 0.18.0
+    oAuthVersion: 0.5.0
+    kafkaVersions: 2.4.0, 2.4.1, 2.5.0
+    kubernetesVersions: 1.11+
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -15,6 +23,10 @@ operator:
     directory_layout: layout2
   - version: 0.18.0
     defaultKafkaVersion: 2.5.0
+    bridgeVersion: 0.16.0
+    oAuthVersion: 0.5.0
+    kafkaVersions: 2.4.0, 2.4.1, 2.5.0
+    kubernetesVersions: 1.11+
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -22,6 +34,10 @@ operator:
     directory_layout: layout2
   - version: 0.17.0
     defaultKafkaVersion: 2.4.0
+    bridgeVersion: 0.15.2
+    oAuthVersion: 0.3.0
+    kafkaVersions: 2.3.1, 2.4.0
+    kubernetesVersions: 1.11+
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -29,24 +45,40 @@ operator:
     directory_layout: layout1
   - version: 0.16.2
     defaultKafkaVersion: 2.4.0
+    bridgeVersion: 0.15.0
+    oAuthVersion: 0.2.0
+    kafkaVersions: 2.3.1, 2.4.0
+    kubernetesVersions: 1.11+
     overview_book: true
     quickstart_book: true
     using_book: true
     directory_layout: layout1
   - version: 0.16.1
     defaultKafkaVersion: 2.4.0
+    bridgeVersion: 0.15.0
+    oAuthVersion: 0.2.0
+    kafkaVersions: 2.3.1, 2.4.0
+    kubernetesVersions: 1.11+
     overview_book: true
     quickstart_book: true
     using_book: true
     directory_layout: layout1
   - version: 0.16.0
     defaultKafkaVersion: 2.4.0
+    bridgeVersion: 0.15.0
+    oAuthVersion: 0.2.0
+    kafkaVersions: 2.3.1, 2.4.0
+    kubernetesVersions: 1.11+
     overview_book: true
     quickstart_book: true
     using_book: true
     directory_layout: layout1
   - version: 0.15.0
     defaultKafkaVersion: 2.3.1
+    bridgeVersion: 0.15.0
+    oAuthVersion: 0.1.0
+    kafkaVersions: 2.2.1, 2.3.0, 2.3.1
+    kubernetesVersions: 1.11+
     overview_book: false
     quickstart_book: true
     using_book: true
@@ -54,6 +86,10 @@ operator:
     directory_layout: layout1
   - version: 0.14.0
     defaultKafkaVersion: 2.3.0
+    bridgeVersion: 0.14.0
+    oAuthVersion: 0.1.0
+    kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1, 2.3.0
+    kubernetesVersions: 1.11+
     overview_book: false
     quickstart_book: false
     using_book: true
@@ -61,6 +97,9 @@ operator:
     directory_layout: layout1
   - version: 0.13.0
     defaultKafkaVersion: 2.3.0
+    bridgeVersion: 0.13.0
+    kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1, 2.3.0
+    kubernetesVersions: 1.11+
     overview_book: false
     quickstart_book: false
     using_book: true
@@ -68,6 +107,9 @@ operator:
     directory_layout: layout1
   - version: 0.12.2
     defaultKafkaVersion: 2.2.1
+    bridgeVersion: 0.12.2
+    kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1
+    kubernetesVersions: 1.11+
     overview_book: false
     quickstart_book: false
     using_book: true
@@ -75,6 +117,9 @@ operator:
     directory_layout: layout1
   - version: 0.12.1
     defaultKafkaVersion: 2.2.1
+    bridgeVersion: 0.12.1
+    kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1
+    kubernetesVersions: 1.11+
     overview_book: false
     quickstart_book: false
     using_book: true
@@ -82,6 +127,9 @@ operator:
     directory_layout: layout1
   - version: 0.12.0
     defaultKafkaVersion: 2.2.1
+    bridgeVersion: 0.12.0
+    kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1
+    kubernetesVersions: 1.11+
     overview_book: false
     quickstart_book: false
     using_book: true

--- a/_includes/downloads/supported-versions-band.html
+++ b/_includes/downloads/supported-versions-band.html
@@ -1,4 +1,4 @@
-<div class="component-slim download-release-band" style="padding-top: 0">
+<div class="component-slim supported-versions-band" style="padding-top: 0">
   <div class="grid-wrapper">
     <div class="width-12-12">
         <h3 style="margin-top: 0">Supported versions</h3>
@@ -8,52 +8,44 @@
       <table class="tg">
         <tr>
           <th>
-            <div class="version-name">
-              Operators
+            <div class="supported-component">
+              Operators<span class="release-date"></span>
             </div>
           </th>
           <th>
-            <div class="version-name">
-              Strimzi Kafka Bridge
+            <div class="supported-component">
+              Strimzi Kafka Bridge<span class="release-date"></span>
             </div>
           </th>
           <th>
-            <div class="version-name">
-              Strimzi OAuth
+            <div class="supported-component">
+              Strimzi OAuth<span class="release-date"></span>
             </div>
           </th>
           <th>
-            <div class="version-name">
-              Kafka versions
+            <div class="supported-component">
+              Kafka versions<span class="release-date"></span>
             </div>
           </th>
           <th>
-            <div class="version-name">
-              Kubernetes versions
+            <div class="supported-component">
+              Kubernetes versions<span class="release-date"></span>
             </div>
           </th>
         </tr>
+
+        {% for oRelease in site.data.releases.operator %}
+          {% if oRelease.kafkaVersions %}
         <tr>
-          <td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.21.0">0.21.0</a></td>
-          <td class="licence">0.19.0</td>
-          <td class="licence">0.7.0</td>
-          <td class="licence">2.7.0, 2.6.0</td>
-          <td class="licence">1.16+</td>
+          <td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{{oRelease.version}}">{{oRelease.version}}</a></td>
+          <td class="version">{% if oRelease.bridgeVersion %}{{oRelease.bridgeVersion}}{% endif %}</td>
+          <td class="version">{% if oRelease.oAuthVersion %}{{oRelease.oAuthVersion}}{% else %}n/a{% endif %}</td>
+          <td class="version">{% if oRelease.kafkaVersions %}{{oRelease.kafkaVersions}}{% endif %}</td>
+          <td class="version">{% if oRelease.kubernetesVersions %}{{oRelease.kubernetesVersions}}{% endif %}</td>
         </tr>
-        <tr>
-          <td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.20.0">0.20.0</a></td>
-          <td class="licence">0.19.0</td>
-          <td class="licence">0.6.1</td>
-          <td class="licence">2.6.0, 2.5.1, 2.5.0</td>
-          <td class="licence">1.11+</td>
-        </tr>
-        <tr>
-          <td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.19.0">0.19.0</a></td>
-          <td class="licence">0.18.0</td>
-          <td class="licence">0.5.0</td>
-          <td class="licence">2.5.0, 2.4.1, 2.4.0</td>
-          <td class="licence">1.11+</td>
-        </tr>
+          {% endif %}
+        {% endfor %}
       </table>
     </div>
+  </div>
 </div>

--- a/_includes/downloads/supported-versions-band.html
+++ b/_includes/downloads/supported-versions-band.html
@@ -1,0 +1,59 @@
+<div class="component-slim download-release-band" style="padding-top: 0">
+  <div class="grid-wrapper">
+    <div class="width-12-12">
+        <h3 style="margin-top: 0">Supported versions</h3>
+    </div>
+
+    <div class="width-12-12 width-12-12-m version-table">
+      <table class="tg">
+        <tr>
+          <th>
+            <div class="version-name">
+              Operators
+            </div>
+          </th>
+          <th>
+            <div class="version-name">
+              Strimzi Kafka Bridge
+            </div>
+          </th>
+          <th>
+            <div class="version-name">
+              Strimzi OAuth
+            </div>
+          </th>
+          <th>
+            <div class="version-name">
+              Kafka versions
+            </div>
+          </th>
+          <th>
+            <div class="version-name">
+              Kubernetes versions
+            </div>
+          </th>
+        </tr>
+        <tr>
+          <td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.21.0">0.21.0</a></td>
+          <td class="licence">0.19.0</td>
+          <td class="licence">0.7.0</td>
+          <td class="licence">2.7.0, 2.6.0</td>
+          <td class="licence">1.16+</td>
+        </tr>
+        <tr>
+          <td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.20.0">0.20.0</a></td>
+          <td class="licence">0.19.0</td>
+          <td class="licence">0.6.1</td>
+          <td class="licence">2.6.0, 2.5.1, 2.5.0</td>
+          <td class="licence">1.11+</td>
+        </tr>
+        <tr>
+          <td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.19.0">0.19.0</a></td>
+          <td class="licence">0.18.0</td>
+          <td class="licence">0.5.0</td>
+          <td class="licence">2.5.0, 2.4.1, 2.4.0</td>
+          <td class="licence">1.11+</td>
+        </tr>
+      </table>
+    </div>
+</div>

--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -4,4 +4,5 @@ layout: base
 
 {% include downloads/downloads-title-band.html %}
 {% include downloads/downloads-release-band.html %}
+{% include downloads/supported-versions-band.html %}
 {% include releases-archives-band.html %}

--- a/_sass/core/includes/supported-versions-band.scss
+++ b/_sass/core/includes/supported-versions-band.scss
@@ -1,0 +1,28 @@
+.supported-versions-band {
+  .version-table {
+    margin-bottom: 1rem;
+    table {
+      width: 100%;
+    }
+    .supported-component {
+      text-align: left;
+      &.final {
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+      .release-date {
+        float: right;
+      }
+    }
+
+    .version { min-width: 3rem; }
+    .links {
+      min-width: 6rem;
+      text-align: right;
+    }
+    td, a { font-size: .875rem; }
+    @media screen and (max-width: 1024px) {
+      grid-column: span 12;
+    }
+  }
+}

--- a/_sass/includes/supported-versions-band.scss
+++ b/_sass/includes/supported-versions-band.scss
@@ -1,0 +1,22 @@
+.supported-versions-band {
+  table {
+    border: 1px solid $blue;
+    border-collapse:collapse;
+    th {
+      background-color: $blue;
+      padding: 1rem;
+      .supported-component, .release-date {
+        color: $white;
+        font-weight: 400;
+        font-size: 1.2rem;
+      }
+    }
+    tbody tr {
+      background-color: transparent;
+      td {
+        border-bottom: 1px solid $blue;
+      }
+    }
+  }
+  h3 { margin-top: 0; }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -23,6 +23,7 @@ $baseurl: "{{ site.baseurl }}";
 @import "core/includes/highlights-alternating-images-band";
 @import "core/includes/highlights-three-columns-band";
 @import "core/includes/download-release-band";
+@import "core/includes/supported-versions-band";
 @import "core/includes/contact-form-band";
 
 @import "project-colors";
@@ -37,6 +38,7 @@ $baseurl: "{{ site.baseurl }}";
 @import "includes/community-contributions-band";
 @import "includes/strimzi_navigation";
 @import "includes/download-release-band";
+@import "includes/supported-versions-band";
 @import "includes/download-archives-band";
 @import "includes/presentation-cards-band";
 @import "includes/homepage-download-announcement-band";


### PR DESCRIPTION
Following the idea from the _Meet the Maintainers_ session, this PR drafts how a new section on the downloads page might look like (content is just dummy right now). Please have a look and let me know what do you think.

I guess other alternative would be to have a separate page with the versions table and only link it from the downloads page.