### PR TITLE
Add more links to the supported versions table

### DIFF
--- a/_includes/downloads/supported-versions-band.html
+++ b/_includes/downloads/supported-versions-band.html
@@ -38,8 +38,8 @@
           {% if oRelease.kafkaVersions %}
         <tr>
           <td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{{oRelease.version}}">{{oRelease.version}}</a></td>
-          <td class="version">{% if oRelease.bridgeVersion %}{{oRelease.bridgeVersion}}{% endif %}</td>
-          <td class="version">{% if oRelease.oAuthVersion %}{{oRelease.oAuthVersion}}{% else %}n/a{% endif %}</td>
+          <td class="version">{% if oRelease.bridgeVersion %}<a href="https://github.com/strimzi/strimzi-kafka-bridge/releases/tag/{{oRelease.bridgeVersion}}">{{oRelease.bridgeVersion}}</a>{% endif %}</td>
+          <td class="version">{% if oRelease.oAuthVersion %}<a href="https://github.com/strimzi/strimzi-kafka-oauth/releases/tag/{{oRelease.oAuthVersion}}">{{oRelease.oAuthVersion}}</a>{% else %}n/a{% endif %}</td>
           <td class="version">{% if oRelease.kafkaVersions %}{{oRelease.kafkaVersions}}{% endif %}</td>
           <td class="version">{% if oRelease.kubernetesVersions %}{{oRelease.kubernetesVersions}}{% endif %}</td>
         </tr>


### PR DESCRIPTION
This PR does a slight improvement to #209 and adds link to the corresponding Bridge and OAuth releases into the table.