### PR TITLE
Fix some typos on the Stirmzi website homepage

### DIFF
--- a/_includes/homepage/homepage-content-band.html
+++ b/_includes/homepage/homepage-content-band.html
@@ -7,10 +7,10 @@
       </div>
       <div class="width-6-12 width-12-12-m">
         <p>
-          Strimzi provides a way to run an Apache Kafka cluster on Kubernetes in various deployment configurations. For development it’s easy to set up a cluster in minikube in a few minutes. For production you can tailor the cluster to your needs, using features such as rack awareness to spread brokers across availability zones, and Kubernetes taints and tolerations to run Kafka on dedicated nodes. You can expose Kafka outside Kubernetes using  NodePort, Load balancer and Ingress, depending on your needs, and these are easily secured using TLS.
+          Strimzi provides a way to run an Apache Kafka cluster on Kubernetes in various deployment configurations. For development it’s easy to set up a cluster in Minikube in a few minutes. For production you can tailor the cluster to your needs, using features such as rack awareness to spread brokers across availability zones, and Kubernetes taints and tolerations to run Kafka on dedicated nodes. You can expose Kafka outside Kubernetes using NodePort, Load balancer, Ingress and OpenShift Routes, depending on your needs, and these are easily secured using TLS.
         </p>
         <p>
-          The Kube-native management of Kafka is not limited to the broker: You can manage Kafka topics, users, mirror maker and Kafka Connect using Custom Resources. This means you can use your familiar kubernetes processes and tooling to manage complete Kafka applications.
+          The Kube-native management of Kafka is not limited to the broker: You can manage Kafka topics, users, Kafka Mirror Maker and Kafka Connect using Custom Resources. This means you can use your familiar Kubernetes processes and tooling to manage complete Kafka applications.
         </p>
       </div>
       <div class="width-6-12 width-12-12-m">

--- a/_includes/homepage/homepage-content-band.html
+++ b/_includes/homepage/homepage-content-band.html
@@ -10,7 +10,7 @@
           Strimzi provides a way to run an Apache Kafka cluster on Kubernetes in various deployment configurations. For development it’s easy to set up a cluster in Minikube in a few minutes. For production you can tailor the cluster to your needs, using features such as rack awareness to spread brokers across availability zones, and Kubernetes taints and tolerations to run Kafka on dedicated nodes. You can expose Kafka outside Kubernetes using NodePort, Load balancer, Ingress and OpenShift Routes, depending on your needs, and these are easily secured using TLS.
         </p>
         <p>
-          The Kube-native management of Kafka is not limited to the broker: You can manage Kafka topics, users, Kafka Mirror Maker and Kafka Connect using Custom Resources. This means you can use your familiar Kubernetes processes and tooling to manage complete Kafka applications.
+          The Kube-native management of Kafka is not limited to the broker. You can also manage Kafka topics, users, Kafka MirrorMaker and Kafka Connect using Custom Resources. This means you can use your familiar Kubernetes processes and tooling to manage complete Kafka applications.
         </p>
       </div>
       <div class="width-6-12 width-12-12-m">

--- a/_includes/homepage/homepage-hero-band.html
+++ b/_includes/homepage/homepage-hero-band.html
@@ -14,7 +14,7 @@
         <h4>Secure by Default</h4>
         <p>
           <ul>
-            <li>Out-of-the Box Security</li>
+            <li>Built-in security</li>
             <li>TLS, SCRAM-SHA, and OAuth authentication</li>
             <li>Automated Certificate Management</li>
           </ul>

--- a/_includes/homepage/homepage-hero-band.html
+++ b/_includes/homepage/homepage-hero-band.html
@@ -14,8 +14,8 @@
         <h4>Secure by Default</h4>
         <p>
           <ul>
-            <li>Out of the Box Security</li>
-            <li>TLS and SCRAM-SHA supported</li>
+            <li>Out-of-the Box Security</li>
+            <li>TLS, SCRAM-SHA, and OAuth authentication</li>
             <li>Automated Certificate Management</li>
           </ul>
         </p>
@@ -34,9 +34,9 @@
         <h4>Kubernetes-Native Experience</h4>
         <p>
           <ul>
-            <li>For example kubectl get kafka</li>
-            <li>Operator Based (<a href="https://kubernetes.io/docs/concepts/extend-kubernetes/operator/">What is an operator?</a>)</li>
-            <li>Manage Kafka using gitops</li>
+            <li>Use kubectl to manage Kafka</li>
+            <li>Operator-based (<a href="https://kubernetes.io/docs/concepts/extend-kubernetes/operator/">What is an operator?</a>)</li>
+            <li>Manage Kafka using GitOps</li>
           </ul>
         </p>
       </div>


### PR DESCRIPTION
While working on the Strimzi Datasheet I noticed some typos and wrong capitalization on the homepage. This Pr tries to fix some of them.