### PR TITLE
Add new API examples to Accessing Kafka blog posts

### DIFF
--- a/_posts/2019-04-23-accessing-kafka-part-2.md
+++ b/_posts/2019-04-23-accessing-kafka-part-2.md
@@ -56,6 +56,19 @@ spec:
     # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: nodeport
+    tls: false
+# ...
+```
+
 But what happens after you configure it is a bit more complicated.
 
 The first thing we need to address is how the clients will access the individual brokers.
@@ -204,6 +217,27 @@ listeners:
 # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: nodeport
+    tls: false
+    configuration:
+      brokers:
+      - broker: 0
+        advertisedHost: XXX.XXX.XXX.XXX
+      - broker: 1
+        advertisedHost: XXX.XXX.XXX.XXX
+      - broker: 2
+        advertisedHost: XXX.XXX.XXX.XXX
+# ...
+```
+
 The overrides can specify either DNS names or IP addresses.
 This solution is not ideal, since you need to maintain the addresses in the custom resource and remember to update them every time you are, for example, scaling up your Kafka cluster.
 But in many cases you might not be able to change the addresses reported by the Kubernetes APIs.
@@ -223,6 +257,20 @@ But you can disable it if you want.
 # ...
 listeners:
   external:
+    type: nodeport
+    tls: false
+# ...
+```
+
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration._
+_In the new configuration, TLS configuration is mandatory and TLS always needs to be explicitly configured._
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
     type: nodeport
     tls: false
 # ...
@@ -269,6 +317,31 @@ listeners:
 # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: nodeport
+    tls: true
+    authentication:
+      type: tls
+    configuration:
+      bootstrap:
+        nodePort: 32100
+      brokers:
+      - broker: 0
+        nodePort: 32000
+      - broker: 1
+        nodePort: 32001
+      - broker: 2
+        nodePort: 32002
+# ...
+```
+
 The example above requests node port `32100` for the bootstrap service and ports `32000`, `32001` and `32002` for the per-broker services.
 This allows you to re-deploy your cluster without changing the node ports numbers in all your applications.
 
@@ -293,6 +366,32 @@ listeners:
     authentication:
       type: tls
     overrides:
+      brokers:
+      - broker: 0
+        advertisedHost: example.hostname.0
+        advertisedPort: 12340
+      - broker: 1
+        advertisedHost: example.hostname.1
+        advertisedPort: 12341
+      - broker: 2
+        advertisedHost: example.hostname.2
+        advertisedPort: 12342
+# ...
+```
+
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: nodeport
+    tls: true
+    authentication:
+      type: tls
+    configuration:
       brokers:
       - broker: 0
         advertisedHost: example.hostname.0

--- a/_posts/2019-04-30-accessing-kafka-part-3.md
+++ b/_posts/2019-04-30-accessing-kafka-part-3.md
@@ -62,6 +62,19 @@ spec:
     # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: route
+    tls: true
+# ...
+```
+
 And the Strimzi Kafka Operator and OpenShift will take care of the rest.
 To provide access to the individual brokers, we use the same tricks as we use with node ports and which were already described in the [previous blog post](https://strimzi.io/2019/04/23/accessing-kafka-part-2.html).
 We create a dedicated service for each of the brokers.
@@ -130,6 +143,31 @@ listeners:
     authentication:
       type: tls
     overrides:
+      bootstrap:
+        host: bootstrap.myrouter.com
+      brokers:
+      - broker: 0
+        host: broker-0.myrouter.com
+      - broker: 1
+        host: broker-1.myrouter.com
+      - broker: 2
+        host: broker-2.myrouter.com
+# ...
+```
+
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: route
+    tls: true
+    authentication:
+      type: tls
+    configuration:
       bootstrap:
         host: bootstrap.myrouter.com
       brokers:

--- a/_posts/2019-05-13-accessing-kafka-part-4.md
+++ b/_posts/2019-05-13-accessing-kafka-part-4.md
@@ -80,6 +80,19 @@ spec:
     # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: loadbalancer
+    tls: true
+# ...
+```
+
 Load balancers, in common with the node port external listener, have TLS enabled by default.
 If you don't want to use TLS encryption, you can easily disable it:
 
@@ -90,6 +103,19 @@ If you don't want to use TLS encryption, you can easily disable it:
         type: loadbalancer
         tls: false
     # ...
+```
+
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: loadbalancer
+    tls: false
+# ...
 ```
 
 After Strimzi creates the load balancer type Kubernetes services, the load balancers will be automatically created.
@@ -147,6 +173,27 @@ listeners:
 # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: loadbalancer
+    tls: true
+    configuration:
+      brokers:
+      - broker: 0
+        advertisedHost: 216.58.201.78
+      - broker: 1
+        advertisedHost: 104.215.148.63
+      - broker: 2
+        advertisedHost: 40.112.72.205
+# ...
+```
+
 I hope that in one of the future versions we will give users a more comfortable option to choose between the IP address and hostname.
 But this feature might be useful to handle also different kinds of network configurations and translations.
 If needed, you can also use it to override the node port numbers as well.
@@ -155,10 +202,36 @@ If needed, you can also use it to override the node port numbers as well.
 # ...
 listeners:
   external:
-    type: route
+    type: loadbalancer
     authentication:
       type: tls
     overrides:
+      brokers:
+      - broker: 0
+        advertisedHost: 216.58.201.78
+        advertisedPort: 12340
+      - broker: 1
+        advertisedHost: 104.215.148.63
+        advertisedPort: 12341
+      - broker: 2
+        advertisedHost: 40.112.72.205
+        advertisedPort: 12342
+# ...
+```
+
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: loadbalancer
+    tls: true
+    authentication:
+      type: tls
+    configuration:
       brokers:
       - broker: 0
         advertisedHost: 216.58.201.78
@@ -220,6 +293,35 @@ spec:
     # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: loadbalancer
+    tls: true
+    authentication:
+      type: tls
+    configuration:
+      bootstrap:
+        annotations:
+          service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+      brokers:
+      - broker: 0
+        annotations:
+          service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+      - broker: 1
+        annotations:
+          service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+      - broker: 2
+        annotations:
+          service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+# ...
+```
+
 You can specify different annotations for the bootstrap and the per-broker services.
 After you specify these annotations, they will be passed by Strimzi to the Kubernetes services, and the load balancers will be created accordingly.
 
@@ -262,6 +364,37 @@ listeners:
 # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: loadbalancer
+    tls: true
+    configuration:
+      bootstrap:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-bootstrap.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      brokers:
+      - broker: 0
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-0.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 1
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-1.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 2
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+# ...
+```
+
 Again, Strimzi lets you configure the annotations directly.
 That gives you more freedom and hopefully makes this feature usable even when you use some other tool then External DNS.
 It also lets you configure other options than just the DNS names, such as the time-to-live of the DNS records etc.
@@ -290,6 +423,38 @@ listeners:
         advertisedHost: kafka-broker-1.mydomain.com
       - broker: 2
         dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
+        advertisedHost: kafka-broker-2.mydomain.com
+# ...
+```
+
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: loadbalancer
+    tls: true
+    configuration:
+      bootstrap:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-bootstrap.mydomain.com.
+        alternativeNames: 
+        - kafka-bootstrap.mydomain.com
+      brokers:
+      - broker: 0
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-0.mydomain.com.
+        advertisedHost: kafka-broker-0.mydomain.com
+      - broker: 1
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-1.mydomain.com.
+        advertisedHost: kafka-broker-1.mydomain.com
+      - broker: 2
+        annotations:
           external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
         advertisedHost: kafka-broker-2.mydomain.com
 # ...

--- a/_posts/2019-05-23-accessing-kafka-part-5.md
+++ b/_posts/2019-05-23-accessing-kafka-part-5.md
@@ -117,6 +117,29 @@ spec:
     # ...
 ```
 
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: ingress
+    tls: true
+    configuration:
+      bootstrap:
+        host: bootstrap.192.168.64.46.nip.io
+      brokers:
+      - broker: 0
+        host: broker-0.192.168.64.46.nip.io
+      - broker: 1
+        host: broker-1.192.168.64.46.nip.io
+      - broker: 2
+        host: broker-2.192.168.64.46.nip.io
+# ...
+```
+
 Using Ingress in your clients is very similar to OpenShift Routes.
 Since it always uses TLS Encryption, you have to first download the server certificate (replace `my-cluster` with the name of your cluster):
 
@@ -183,6 +206,41 @@ listeners:
           external-dns.alpha.kubernetes.io/ttl: "60"
       - broker: 2
         dnsAnnotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+# ...
+```
+
+_Update: Since version 0.20.0, Strimzi uses a new format for listener configuration:_
+
+```yaml
+# ...
+listeners:
+  # ...
+  - name: external
+    port: 9094
+    type: ingress
+    tls: true
+    configuration:
+      bootstrap:
+        host: kafka-bootstrap.mydomain.com
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-bootstrap.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      brokers:
+      - broker: 0
+        host: kafka-broker-0.mydomain.com
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-0.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 1
+        host: kafka-broker-1.mydomain.com
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: kafka-broker-1.mydomain.com.
+          external-dns.alpha.kubernetes.io/ttl: "60"
+      - broker: 2
+        host: kafka-broker-2.mydomain.com
+        annotations:
           external-dns.alpha.kubernetes.io/hostname: kafka-broker-2.mydomain.com.
           external-dns.alpha.kubernetes.io/ttl: "60"
 # ...


### PR DESCRIPTION
It looks like lot of people still use the _Accessing Kafka_ blog post series. But the YAML examples it contains are not supported anymore. This PR adds additional examples to them using the new APIs.