### PR TITLE
Fixed inconsistent link color behaviour

### DIFF
--- a/_sass/includes/project-footer.scss
+++ b/_sass/includes/project-footer.scss
@@ -30,9 +30,11 @@
   p {
     margin-top: 0;
     margin-bottom: 0;
-
-    a:visited {
-      color: $link-dark-bg !important; 
+    a {
+      color: $link-dark-bg !important;
+      &:hover, &:hover i {
+        color: $link-hover-dark-bg !important;
+      }
     }
   }
 

--- a/_sass/includes/strimzi_navigation.scss
+++ b/_sass/includes/strimzi_navigation.scss
@@ -74,7 +74,7 @@ div.nav-wrapper {
       display: block;
       padding: 15px;
 
-      &:hover {
+      &:hover, &:hover i {
         color: $orange !important;
       }
     }

--- a/_sass/strimzi.scss
+++ b/_sass/strimzi.scss
@@ -96,11 +96,11 @@ a, a i {
   cursor: pointer;
   text-decoration: underline;
   color: $link !important;
-  &:hover, &:active, &:focus {
-    color: $link-hover;
-  }
   &:visited {
     color: $link-visited;
+  }
+  &:hover {
+    color: $link-hover !important;
   }
 }
 
@@ -273,11 +273,11 @@ blockquote::after {
 
   a, a i {
     color: $link-dark-bg !important;
-    &:hover, &:active, &:focus {
-      color: $link-hover-dark-bg !important;
-    }
     &:visited {
       color: $link-visited-dark-bg !important;
+    }
+    &:hover {
+      color: $link-hover-dark-bg !important;
     }
   }
 }


### PR DESCRIPTION
This pull request is a fix for the inconsistent link color behaviour #218.

Changes per component:
- Menu: icon links (GitHub, Twitter and YouTube) now also change color on hover event.
- Footer: icon links (GitHub, Twitter and YouTube) label also trigger child element `<i>` to change color on hover event.
- Project/global: moved the hover event after the visited event styling, so that hover event styling ranks higher. Also made link color `!important`, because this is used throughout the styling.

![Screenshot 2021-03-28 at 17 40 03](https://user-images.githubusercontent.com/16334194/112758068-c2e87480-8fec-11eb-8461-b25dd8a4c446.png)
Menu icons now have color applied on hover event.

![Screenshot 2021-03-28 at 17 40 16](https://user-images.githubusercontent.com/16334194/112758074-ca0f8280-8fec-11eb-93e0-5f95cd6e0be2.png)
Footer icon and label color applied on label hover event.

![Screenshot 2021-03-28 at 17 40 26](https://user-images.githubusercontent.com/16334194/112758089-d5fb4480-8fec-11eb-8683-4fa627f8673a.png)
Other links are now working as well.

I noticed some improvements and refactoring we can do in the .scss files, will create some GitHub issues for these. For example, removing the `!important` throughout the styling and in most places the project global color variables are not used.