### PR TITLE
Fix the URL in the examples redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -3,7 +3,7 @@
 
 # Redirects to the latest all-in-one install file and examples
 /install/latest                     https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.22.1/strimzi-cluster-operator-0.22.1.yaml     200
-/examples/latest/*                  https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.22.1/examples/:splat                             200
+/examples/latest/*                  https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/examples/:splat                             200
 
 # Redirects for old website URL structure
 /2018/:month/:date/:slug            /blog/2018/:month/:date/:slug                                                                                       301


### PR DESCRIPTION
The URL shortcut for example files through `https://strimzi.io/examples/latest/...` currently points to wrong set of examples. This is due to the move between `example/` and `packaging/examples/`. This PR fixes it to point to the examples to the right place for the `v1beta2` examples.