### PR TITLE
Add link to full docs

### DIFF
--- a/_includes/documentation/documentation-archive-band.html
+++ b/_includes/documentation/documentation-archive-band.html
@@ -13,18 +13,18 @@
         {% if oRelease.directory_layout == "layout2" %}
           <h5>{{oRelease.version}}</h5>
           <ul>
-            {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/overview.html">Overview guide</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/overview.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
-            {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/quickstart.html">Quick Start guide</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/quickstart.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
-            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying and Upgrading</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/deploying.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
-            {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/using.html">Using Strimzi</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/using.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/overview.html">Overview guide</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/overview.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/quickstart.html">Quick Start guide</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/quickstart.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying and Upgrading</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/deploying.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/using.html">Using Strimzi</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/using.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
           </ul>
         {% elsif oRelease.directory_layout == "layout1" %}
           <h5>{{oRelease.version}}</h5>
           <ul>
-            {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/overview/{{oRelease.version}}">Overview guide</a> <a href="{{site.baseurl}}/docs/overview/{{oRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
-            {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/quickstart/{{oRelease.version}}">Quick Start guide</a> <a href="{{site.baseurl}}/docs/quickstart/{{oRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
-            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/deploying/{{oRelease.version}}">Deploying Strimzi</a> <a href="{{site.baseurl}}/docs/deploying/{{oRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
-            {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/{{oRelease.version}}">Using Strimzi</a> <a href="{{site.baseurl}}/docs/{{oRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/overview/{{oRelease.version}}">Overview guide</a> <a href="{{site.baseurl}}/docs/overview/{{oRelease.version}}/full.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/quickstart/{{oRelease.version}}">Quick Start guide</a> <a href="{{site.baseurl}}/docs/quickstart/{{oRelease.version}}/full.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/deploying/{{oRelease.version}}">Deploying Strimzi</a> <a href="{{site.baseurl}}/docs/deploying/{{oRelease.version}}/full.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/{{oRelease.version}}">Using Strimzi</a> <a href="{{site.baseurl}}/docs/{{oRelease.version}}/full.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
           </ul>          
         {% elsif oRelease.directory_layout == "layout0" %}
           <h5>{{oRelease.version}}</h5>
@@ -38,7 +38,7 @@
       <h4>Strimzi Kafka Bridge</h4>
       {% for bRelease in site.data.releases.bridge %}
           <ul>
-            <li><a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}">{{bRelease.version}}</a> <a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>
+            <li><a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}">{{bRelease.version}}</a> <a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}/full.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>
           </ul>
       {% endfor %}
     </div>

--- a/_includes/documentation/documentation-archive-band.html
+++ b/_includes/documentation/documentation-archive-band.html
@@ -13,18 +13,18 @@
         {% if oRelease.directory_layout == "layout2" %}
           <h5>{{oRelease.version}}</h5>
           <ul>
-            {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/overview.html">Overview guide</a></li>{% endif %}
-            {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/quickstart.html">Quick Start guide</a></li>{% endif %}
-            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying and Upgrading</a></li>{% endif %}
-            {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/using.html">Using Strimzi</a></li>{% endif %}
+            {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/overview.html">Overview guide</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/overview.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/quickstart.html">Quick Start guide</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/quickstart.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying and Upgrading</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/deploying.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/using.html">Using Strimzi</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/using.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
           </ul>
         {% elsif oRelease.directory_layout == "layout1" %}
           <h5>{{oRelease.version}}</h5>
           <ul>
-            {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/overview/{{oRelease.version}}">Overview guide</a></li>{% endif %}
-            {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/quickstart/{{oRelease.version}}">Quick Start guide</a></li>{% endif %}
-            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/deploying/{{oRelease.version}}">Deploying Strimzi</a></li>{% endif %}
-            {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/{{oRelease.version}}">Using Strimzi</a></li>{% endif %}
+            {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/overview/{{oRelease.version}}">Overview guide</a> <a href="{{site.baseurl}}/docs/overview/{{oRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.quickstart_book %}<li><a href="{{site.baseurl}}/docs/quickstart/{{oRelease.version}}">Quick Start guide</a> <a href="{{site.baseurl}}/docs/quickstart/{{oRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/deploying/{{oRelease.version}}">Deploying Strimzi</a> <a href="{{site.baseurl}}/docs/deploying/{{oRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.using_book %}<li><a href="{{site.baseurl}}/docs/{{oRelease.version}}">Using Strimzi</a> <a href="{{site.baseurl}}/docs/{{oRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
           </ul>          
         {% elsif oRelease.directory_layout == "layout0" %}
           <h5>{{oRelease.version}}</h5>
@@ -38,7 +38,7 @@
       <h4>Strimzi Kafka Bridge</h4>
       {% for bRelease in site.data.releases.bridge %}
           <ul>
-            <li><a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}">{{bRelease.version}}</a></li>
+            <li><a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}">{{bRelease.version}}</a> <a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>
           </ul>
       {% endfor %}
     </div>

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -3,23 +3,23 @@
     <div class="width-12-12">
       <h3>Documentation for Version {{site.data.releases.operator[0].version}} - latest stable release</h3>
     </div>
-    <div class="width-6-12 width-12-12-m">
+    <div class="width-6-12 width-12-12-m documentation-verion-band">
       <p>
         <strong class="text-caps">Strimzi Kafka Operators Documentation</strong>
         <br/>
-        Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
-        Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
-        Deploying and Upgrading: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
-        Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a><br/>
+        Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/overview.html" target="_blank"><i class="fas fa-external-link-alt"></i> </a><br/>
+        Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/quickstart.html" target="_blank"><i class="fas fa-external-link-alt"> </i></a><br/>
+        Deploying and Upgrading: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/deploying.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
+        Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/using.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
         Example custom resources: <a href="{{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples">{{site.data.releases.operator[0].version}} - latest stable release</a>
       </p><br/>
       <p>
         <strong class="text-caps">Strimzi Kafka Bridge Documentation</strong>
         <br/>
-        <a href="{{site.baseurl}}/docs/bridge/latest/">{{site.data.releases.bridge[0].version}} - latest stable release</a>
+        <a href="{{site.baseurl}}/docs/bridge/latest/">{{site.data.releases.bridge[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/bridge/latest/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a>
       </p>
     </div>
-    <div class="width-6-12 width-12-12-m">
+    <div class="width-6-12 width-12-12-m documentation-verion-band">
       <p>
         <strong class="text-caps">In Development Documentation</strong>
         <br/>
@@ -27,13 +27,13 @@
       </p>
       <p>
         Strimzi Kafka operators (In Development)<br>
-        <a href="{{site.baseurl}}/docs/operators/in-development/overview.html">Overview guide</a> |
-        <a href="{{site.baseurl}}/docs/operators/in-development/quickstart.html">Quick Start guide</a> |
-        <a href="{{site.baseurl}}/docs/operators/in-development/deploying.html">Deploying and Upgrading</a> |<br/>
-        <a href="{{site.baseurl}}/docs/operators/in-development/using.html">Using Strimzi</a> | 
+        <a href="{{site.baseurl}}/docs/operators/in-development/overview.html">Overview guide</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/overview.html" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
+        <a href="{{site.baseurl}}/docs/operators/in-development/quickstart.html">Quick Start guide</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/quickstart.html" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
+        <a href="{{site.baseurl}}/docs/operators/in-development/deploying.html">Deploying and Upgrading</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/deploying.html" target="_blank"><i class="fas fa-external-link-alt"></i></a> |<br/>
+        <a href="{{site.baseurl}}/docs/operators/in-development/using.html">Using Strimzi</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/using.html" target="_blank"><i class="fas fa-external-link-alt"></i></a> | 
         <a href="{{site.github_url}}/strimzi-kafka-operator/tree/main/examples">Example custom resources</a>
       </p>
-      <p>Strimzi Kafka Bridge: <a href="{{site.baseurl}}/docs/bridge/in-development/">In Development</a></p>
+      <p>Strimzi Kafka Bridge: <a href="{{site.baseurl}}/docs/bridge/in-development/">In Development</a> <a href="{{site.baseurl}}/docs/bridge/in-development/full/bridge.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></p>
     </div>
   </div>
 </div>

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -7,8 +7,8 @@
       <p>
         <strong class="text-caps">Strimzi Kafka Operators Documentation</strong>
         <br/>
-        Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/overview.html" target="_blank"><i class="fas fa-external-link-alt"></i> </a><br/>
-        Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/quickstart.html" target="_blank"><i class="fas fa-external-link-alt"> </i></a><br/>
+        Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/overview.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
+        Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/quickstart.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
         Deploying and Upgrading: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/deploying.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
         Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/using.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
         Example custom resources: <a href="{{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples">{{site.data.releases.operator[0].version}} - latest stable release</a>

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -3,7 +3,7 @@
     <div class="width-12-12">
       <h3>Documentation for Version {{site.data.releases.operator[0].version}} - latest stable release</h3>
     </div>
-    <div class="width-6-12 width-12-12-m documentation-verion-band">
+    <div class="width-6-12 width-12-12-m documentation-version-band">
       <p>
         <strong class="text-caps">Strimzi Kafka Operators Documentation</strong>
         <br/>
@@ -19,7 +19,7 @@
         <a href="{{site.baseurl}}/docs/bridge/latest/">{{site.data.releases.bridge[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/bridge/latest/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a>
       </p>
     </div>
-    <div class="width-6-12 width-12-12-m documentation-verion-band">
+    <div class="width-6-12 width-12-12-m documentation-version-band">
       <p>
         <strong class="text-caps">In Development Documentation</strong>
         <br/>

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -7,10 +7,10 @@
       <p>
         <strong class="text-caps">Strimzi Kafka Operators Documentation</strong>
         <br/>
-        Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/overview.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
-        Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/quickstart.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
-        Deploying and Upgrading: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/deploying.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
-        Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/using.html" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
+        Overview guide: <a href="{{site.baseurl}}/docs/operators/latest/overview.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/overview.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
+        Quick Start guide: <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/quickstart.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
+        Deploying and Upgrading: <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/deploying.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
+        Using Strimzi: <a href="{{site.baseurl}}/docs/operators/latest/using.html">{{site.data.releases.operator[0].version}} - latest stable release</a> <a href="{{site.baseurl}}/docs/operators/latest/full/using.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a><br/>
         Example custom resources: <a href="{{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples">{{site.data.releases.operator[0].version}} - latest stable release</a>
       </p><br/>
       <p>
@@ -27,13 +27,13 @@
       </p>
       <p>
         Strimzi Kafka operators (In Development)<br>
-        <a href="{{site.baseurl}}/docs/operators/in-development/overview.html">Overview guide</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/overview.html" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
-        <a href="{{site.baseurl}}/docs/operators/in-development/quickstart.html">Quick Start guide</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/quickstart.html" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
-        <a href="{{site.baseurl}}/docs/operators/in-development/deploying.html">Deploying and Upgrading</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/deploying.html" target="_blank"><i class="fas fa-external-link-alt"></i></a> |<br/>
-        <a href="{{site.baseurl}}/docs/operators/in-development/using.html">Using Strimzi</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/using.html" target="_blank"><i class="fas fa-external-link-alt"></i></a> | 
+        <a href="{{site.baseurl}}/docs/operators/in-development/overview.html">Overview guide</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/overview.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
+        <a href="{{site.baseurl}}/docs/operators/in-development/quickstart.html">Quick Start guide</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/quickstart.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
+        <a href="{{site.baseurl}}/docs/operators/in-development/deploying.html">Deploying and Upgrading</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/deploying.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> |<br/>
+        <a href="{{site.baseurl}}/docs/operators/in-development/using.html">Using Strimzi</a>  <a href="{{site.baseurl}}/docs/operators/in-development/full/using.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> | 
         <a href="{{site.github_url}}/strimzi-kafka-operator/tree/main/examples">Example custom resources</a>
       </p>
-      <p>Strimzi Kafka Bridge: <a href="{{site.baseurl}}/docs/bridge/in-development/">In Development</a> <a href="{{site.baseurl}}/docs/bridge/in-development/full/bridge.html" target="_blank"><i class="fas fa-external-link-alt"></i></a></p>
+      <p>Strimzi Kafka Bridge: <a href="{{site.baseurl}}/docs/bridge/in-development/">In Development</a> <a href="{{site.baseurl}}/docs/bridge/in-development/full/bridge.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></p>
     </div>
   </div>
 </div>

--- a/_sass/core/includes/secondary-page-title-band.scss
+++ b/_sass/core/includes/secondary-page-title-band.scss
@@ -1,5 +1,5 @@
 .secondary-page-title-band {
-  .documentation-verion-band {
+  .documentation-version-band {
     i {
       color: $white !important;
       text-decoration: none;

--- a/_sass/core/includes/secondary-page-title-band.scss
+++ b/_sass/core/includes/secondary-page-title-band.scss
@@ -1,3 +1,8 @@
 .secondary-page-title-band {
-
+  .documentation-verion-band {
+    i {
+      color: $white !important;
+      text-decoration: none;
+    }
+  }
 }

--- a/_sass/includes/download-archives-band.scss
+++ b/_sass/includes/download-archives-band.scss
@@ -6,4 +6,8 @@
   }
   
   h3 { margin: 0; }
+
+  i {
+    text-decoration: none;
+  }
 }


### PR DESCRIPTION
Currently, the website has two versions of the documentation: one is embedded into the website it self:
* for example https://strimzi.io/docs/operators/latest/quickstart.html

Other one is using the default Asciidoc rendered:
* for example https://strimzi.io/docs/operators/latest/full/quickstart.html

To get to the other one, you need to know how to change the URL. But in some cases, the full documentation is more readable. So this PR adds new icons to the documentation website which can be used to directly open the _full_ documentation in a new window.

![Screenshot 2021-04-16 at 0 14 20](https://user-images.githubusercontent.com/5658439/114944956-cda66480-9e48-11eb-9f8d-8f90af2c2c8f.png)

@strimzi/maintainers please have a look at this and let me know what do you think about it. You can also try it in the preview.