### PR TITLE
Fix typo in Cruise Control blog post

### DIFF
--- a/_posts/2020-06-05-cruise-control.md
+++ b/_posts/2020-06-05-cruise-control.md
@@ -128,7 +128,7 @@ metadata:
   name: my-rebalance
   labels:
     strimzi.io/cluster: my-cluster
-  spec: {}
+spec: {}
 ```
 
 And you can deploy this like any other resource:


### PR DESCRIPTION
This Pr fixes a small typo in the Cruise Control blog pot reported by a user on Slack: https://cloud-native.slack.com/archives/CMH3Q3SNP/p1619098604217700