### PR TITLE
Fix font size of code formatted text

### DIFF
--- a/_sass/core/global.scss
+++ b/_sass/core/global.scss
@@ -180,7 +180,7 @@ code > * {
 pre > code {
   padding: .5rem 1rem;
   background-color: transparent;
-  font-size: 1.2em;
+  font-size: 1em;
 }
 
 hr {

--- a/_sass/strimzi.scss
+++ b/_sass/strimzi.scss
@@ -135,7 +135,7 @@ code {
 
 p code,
 li code {
-  font-size: 1.2em;
+  font-size: 1em;
   line-height: 1.5;
 }
 


### PR DESCRIPTION
The text formatted as code seems to be using bigger font than the text around it (I guess technically it is not bigger, but it looks like it because of different font). This PR tries to fix the font size to make it look better.