### PR TITLE
Use the same order for TAR.GZ and ZIP links everywhere

### DIFF
--- a/_includes/downloads/downloads-release-band.html
+++ b/_includes/downloads/downloads-release-band.html
@@ -61,8 +61,8 @@
             <td class="description">Source Code</td>
             <td class="licence">AL 2.0</td>
             <td class="links">
-              <a href="https://github.com/strimzi/strimzi-kafka-operator/archive/{{oRelease}}.zip">zip</a>&nbsp;&#124;&nbsp;
-              <a href="https://github.com/strimzi/strimzi-kafka-operator/archive/{{oRelease}}.tar.gz">tar.gz</a>
+              <a href="https://github.com/strimzi/strimzi-kafka-operator/archive/{{oRelease}}.tar.gz">tar.gz</a>&nbsp;&#124;&nbsp;
+              <a href="https://github.com/strimzi/strimzi-kafka-operator/archive/{{oRelease}}.zip">zip</a>
             </td>
           </tr>
         </table>
@@ -90,8 +90,8 @@
             <td class="description">Source Code</td>
             <td class="licence">AL 2.0</td>
             <td class="links">
-              <a href="https://github.com/strimzi/strimzi-kafka-bridge/archive/{{bRelease}}.zip">zip</a>&nbsp;&#124;&nbsp;
-              <a href="https://github.com/strimzi/strimzi-kafka-bridge/archive/{{bRelease}}.tar.gz">tar.gz</a>
+              <a href="https://github.com/strimzi/strimzi-kafka-bridge/archive/{{bRelease}}.tar.gz">tar.gz</a>&nbsp;&#124;&nbsp;
+              <a href="https://github.com/strimzi/strimzi-kafka-bridge/archive/{{bRelease}}.zip">zip</a>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
On the downloads page, we have several release artifacts which are available as TAR.GZ and ZIP archives. It would make sense to use everywhere the same order in which the archives are listed.