### PR TITLE
Fix incorrect reference to Docker Hub

### DIFF
--- a/_includes/downloads/downloads-release-band.html
+++ b/_includes/downloads/downloads-release-band.html
@@ -100,6 +100,7 @@
     <div class="width-12-12">
       <p>Full list of changes can be found under the <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{{site.data.releases.operator[0].version}}">{{site.data.releases.operator[0].version}} release</a>.</p>
       <p><strong>Upgrading from Strimzi {{site.data.releases.operator[1].version}}? See the <a href="{{site.baseurl}}/documentation/">documentation</a> for upgrade instructions.</strong></p>
+      <p>The container images are available under the <a href="https://quay.io/organization/strimzi">Strimzi organization</a> in the Quay.io container registry.</p>
     </div>
   </div>
 </div>

--- a/_includes/downloads/downloads-title-band.html
+++ b/_includes/downloads/downloads-title-band.html
@@ -3,7 +3,7 @@
     <div class="component-slim grid-wrapper">
       <div class="width-12-12">
         <h1>Downloads</h1>
-        <h3>Strimzi releases are available for download on our GitHub. The release artifacts contain documentation and example YAML files for deployment on Kubernetes. The Docker images are available on Docker Hub.</h3>
+        <h3>Strimzi releases are available for download on our GitHub. The release artifacts contain documentation and example YAML files for deployment on Kubernetes.</h3>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The Download page in our website has a reference to Docker Hub which we no longer use:
![Screenshot 2021-11-08 at 20 45 53](https://user-images.githubusercontent.com/5658439/140807915-6e1da5e6-61c9-4beb-9425-f5c626789cc0.png)

This PR removes it completely from the sub-header. And instead adds link below the release table pointing to the Quay registry. Since the container images are not really usable on their own, I do not think they need to be pointed to in the sub-header:
![Screenshot 2021-11-08 at 20 51 15](https://user-images.githubusercontent.com/5658439/140808429-8740b8dd-552d-4a45-9b9b-235aaee4ffd5.png)