### PR TITLE
Fix the version in the 0.26.0 docs

### DIFF
--- a/docs/operators/0.26.0/contributing-book.html
+++ b/docs/operators/0.26.0/contributing-book.html
@@ -2316,7 +2316,7 @@ Fast-forwarded &lt;new-topic-branch&gt; to &lt;user&gt;/&lt;merge-request-branch
 </ol>
 </div>
 <div class="paragraph">
-<p><em>Revised on 2021-10-15 11:27:40 +0200</em></p>
+<p><em>Revised on 2021-11-15 17:04:26 +0100</em></p>
 </div>
 </div>
 </div>

--- a/docs/operators/0.26.0/deploying-book.html
+++ b/docs/operators/0.26.0/deploying-book.html
@@ -883,7 +883,7 @@ Example configuration files for custom resources contain important properties an
 </div>
 <div class="paragraph">
 <p>You can also access the example files directly from the
-<a href="https://github.com/strimzi/strimzi-kafka-operator/tree/main/examples/" target="_blank" rel="noopener"><code>examples</code> directory</a>.</p>
+<a href="https://github.com/strimzi/strimzi-kafka-operator/tree/0.26.0/examples/" target="_blank" rel="noopener"><code>examples</code> directory</a>.</p>
 </div>
 <div class="paragraph">
 <p>You can download and apply the examples using the <code>kubectl</code> command-line tool.
@@ -1019,13 +1019,13 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-2.8.0</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-2.8.0</p>
 </li>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-2.8.1</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-2.8.1</p>
 </li>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-3.0.0</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1057,7 +1057,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/operator:latest</p>
+<p>quay.io/strimzi/operator:0.26.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1099,7 +1099,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/jmxtrans:latest</p>
+<p>quay.io/strimzi/jmxtrans:0.26.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1536,7 +1536,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: quay.io/strimzi/operator:latest
+        image: quay.io/strimzi/operator:0.26.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -1632,7 +1632,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: quay.io/strimzi/operator:latest
+        image: quay.io/strimzi/operator:0.26.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -2868,10 +2868,10 @@ spec: # <b class="conum">(1)</b>
 <div class="title">Procedure</div>
 <ol class="arabic">
 <li>
-<p>Create a new <code>Dockerfile</code> using <code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> as the base image:</p>
+<p>Create a new <code>Dockerfile</code> using <code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> as the base image:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:latest-kafka-3.0.0
+<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -3699,7 +3699,7 @@ and require familiarity with the <a href="./using.html#assembly-deployment-confi
 <p>Deploy a Kafka producer.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
 </div>
 </div>
 </li>
@@ -3713,7 +3713,7 @@ and require familiarity with the <a href="./using.html#assembly-deployment-confi
 <p>Deploy a Kafka consumer.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
 </div>
 </div>
 </li>
@@ -5521,7 +5521,7 @@ The name of the Grafana pod is different for each user.</p>
 <h2 id="assembly-upgrade-str"><a class="link" href="#assembly-upgrade-str">7. Upgrading Strimzi</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Strimzi can be upgraded to version latest to take advantage of new features and enhancements, performance improvements, and security options.</p>
+<p>Strimzi can be upgraded to version 0.26.0 to take advantage of new features and enhancements, performance improvements, and security options.</p>
 </div>
 <div class="paragraph">
 <p>As part of the upgrade, you upgrade Kafka to the latest supported version.
@@ -5538,11 +5538,11 @@ Each Kafka release introduces new features, improvements, and bug fixes to your 
 <dl>
 <dt class="hdlist1">Incremental</dt>
 <dd>
-<p>Upgrading Strimzi from the previous minor version to version latest.</p>
+<p>Upgrading Strimzi from the previous minor version to version 0.26.0.</p>
 </dd>
 <dt class="hdlist1">Multi-version</dt>
 <dd>
-<p>Upgrading Strimzi from an old version to version latest within a single upgrade (skipping one or more intermediate versions).</p>
+<p>Upgrading Strimzi from an old version to version 0.26.0 within a single upgrade (skipping one or more intermediate versions).</p>
 <div class="paragraph">
 <p>For example, upgrading from Strimzi 0.20.0 directly to Strimzi 0.22.</p>
 </div>
@@ -5636,7 +5636,7 @@ A reduction in cluster availability increases the chance that a broker failure w
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
-<p>Strimzi latest requires Kubernetes 1.16 and later.</p>
+<p>Strimzi 0.26.0 requires Kubernetes 1.16 and later.</p>
 </div>
 </div>
 </div>
@@ -5878,7 +5878,7 @@ For example, <code>my-cluster-kafka-0</code>.</p>
 <div class="sect2">
 <h3 id="assembly-upgrade-resources-str"><a class="link" href="#assembly-upgrade-resources-str">7.3. Strimzi custom resource upgrades</a></h3>
 <div class="paragraph">
-<p>When upgrading Strimzi to latest from 0.22 or earlier, you must ensure that your custom resources are using API version <code>v1beta2</code>.
+<p>When upgrading Strimzi to 0.26.0 from 0.22 or earlier, you must ensure that your custom resources are using API version <code>v1beta2</code>.
 You must upgrade the Custom Resource Definitions and the custom resources <strong>before</strong> upgrading to Strimzi 0.23 or newer.
 To perform the upgrade, you can use the <em>API conversion tool</em> provided with Strimzi 0.24.
 For more information, see the <a href="https://strimzi.io/docs/operators/0.24.0/deploying.html#assembly-upgrade-resources-str" target="_blank" rel="noopener">Strimzi 0.24.0 upgrade documentation</a>.</p>
@@ -5887,7 +5887,7 @@ For more information, see the <a href="https://strimzi.io/docs/operators/0.24.0/
 <div class="sect2">
 <h3 id="proc-upgrading-the-co-str"><a class="link" href="#proc-upgrading-the-co-str">7.4. Upgrading the Cluster Operator</a></h3>
 <div class="paragraph">
-<p>This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi latest.</p>
+<p>This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi 0.26.0.</p>
 </div>
 <div class="paragraph">
 <p>Follow this procedure if you deployed the Cluster Operator using the installation YAML files rather than <a href="https://operatorhub.io/" target="_blank" rel="noopener">OperatorHub.io</a>.</p>
@@ -5914,7 +5914,7 @@ Refer to the documentation supporting a specific version of Strimzi for informat
 <p>An existing Cluster Operator deployment is available.</p>
 </li>
 <li>
-<p>You have <a href="#downloads-str">downloaded the release artifacts for Strimzi latest</a>.</p>
+<p>You have <a href="#downloads-str">downloaded the release artifacts for Strimzi 0.26.0</a>.</p>
 </li>
 </ul>
 </div>
@@ -5926,7 +5926,7 @@ Refer to the documentation supporting a specific version of Strimzi for informat
 Any changes will be <strong>overwritten</strong> by the new version of the Cluster Operator.</p>
 </li>
 <li>
-<p>Update your custom resources to reflect the supported configuration options available for Strimzi version latest.</p>
+<p>Update your custom resources to reflect the supported configuration options available for Strimzi version 0.26.0.</p>
 </li>
 <li>
 <p>Update the Cluster Operator.</p>
@@ -6014,14 +6014,14 @@ You will upgrade the Kafka version later.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">quay.io/strimzi/kafka:latest-kafka-3.0.0</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code></pre>
 </div>
 </div>
 </li>
 </ol>
 </div>
 <div class="paragraph">
-<p>Your Cluster Operator was upgraded to version latest but the version of Kafka running in the cluster it manages is unchanged.</p>
+<p>Your Cluster Operator was upgraded to version 0.26.0 but the version of Kafka running in the cluster it manages is unchanged.</p>
 </div>
 <div class="paragraph">
 <p>Following the Cluster Operator upgrade, you must perform a <a href="#assembly-upgrading-kafka-versions-str">Kafka upgrade</a>.</p>
@@ -6030,7 +6030,7 @@ You will upgrade the Kafka version later.</p>
 <div class="sect2">
 <h3 id="assembly-upgrading-kafka-versions-str"><a class="link" href="#assembly-upgrading-kafka-versions-str">7.5. Upgrading Kafka</a></h3>
 <div class="paragraph">
-<p>After you have upgraded your Cluster Operator to latest, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.</p>
+<p>After you have upgraded your Cluster Operator to 0.26.0, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.</p>
 </div>
 <div class="paragraph">
 <p>Kafka upgrades are performed by the Cluster Operator through rolling updates of the Kafka brokers.</p>
@@ -6979,7 +6979,7 @@ You must format the value of <code>log.message.format.version</code> and <code>i
 <p>If you are reverting back to a version of Strimzi earlier than 0.22, which uses ZooKeeper for the storage of topic metadata, delete the internal topic store topics from the Kafka cluster.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 </li>

--- a/docs/operators/0.26.0/full/contributing.html
+++ b/docs/operators/0.26.0/full/contributing.html
@@ -2762,7 +2762,7 @@ Fast-forwarded &lt;new-topic-branch&gt; to &lt;user&gt;/&lt;merge-request-branch
 </ol>
 </div>
 <div class="paragraph">
-<p><em>Revised on 2021-10-15 11:27:33 +0200</em></p>
+<p><em>Revised on 2021-11-15 17:04:43 +0100</em></p>
 </div>
 </div>
 </div>
@@ -2770,7 +2770,7 @@ Fast-forwarded &lt;new-topic-branch&gt; to &lt;user&gt;/&lt;merge-request-branch
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-05-13 20:12:43 +0200
+Last updated 2021-11-15 16:59:49 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/0.26.0/full/deploying.html
+++ b/docs/operators/0.26.0/full/deploying.html
@@ -1329,7 +1329,7 @@ Example configuration files for custom resources contain important properties an
 </div>
 <div class="paragraph">
 <p>You can also access the example files directly from the
-<a href="https://github.com/strimzi/strimzi-kafka-operator/tree/main/examples/" target="_blank" rel="noopener"><code>examples</code> directory</a>.</p>
+<a href="https://github.com/strimzi/strimzi-kafka-operator/tree/0.26.0/examples/" target="_blank" rel="noopener"><code>examples</code> directory</a>.</p>
 </div>
 <div class="paragraph">
 <p>You can download and apply the examples using the <code>kubectl</code> command-line tool.
@@ -1465,13 +1465,13 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-2.8.0</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-2.8.0</p>
 </li>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-2.8.1</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-2.8.1</p>
 </li>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-3.0.0</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1503,7 +1503,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/operator:latest</p>
+<p>quay.io/strimzi/operator:0.26.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1545,7 +1545,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/jmxtrans:latest</p>
+<p>quay.io/strimzi/jmxtrans:0.26.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1982,7 +1982,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: quay.io/strimzi/operator:latest
+        image: quay.io/strimzi/operator:0.26.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -2078,7 +2078,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: quay.io/strimzi/operator:latest
+        image: quay.io/strimzi/operator:0.26.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -3314,10 +3314,10 @@ spec: # <b class="conum">(1)</b>
 <div class="title">Procedure</div>
 <ol class="arabic">
 <li>
-<p>Create a new <code>Dockerfile</code> using <code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> as the base image:</p>
+<p>Create a new <code>Dockerfile</code> using <code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> as the base image:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:latest-kafka-3.0.0
+<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -4145,7 +4145,7 @@ and require familiarity with the <a href="./using.html#assembly-deployment-confi
 <p>Deploy a Kafka producer.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
 </div>
 </div>
 </li>
@@ -4159,7 +4159,7 @@ and require familiarity with the <a href="./using.html#assembly-deployment-confi
 <p>Deploy a Kafka consumer.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
 </div>
 </div>
 </li>
@@ -5967,7 +5967,7 @@ The name of the Grafana pod is different for each user.</p>
 <h2 id="assembly-upgrade-str"><a class="link" href="#assembly-upgrade-str">7. Upgrading Strimzi</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Strimzi can be upgraded to version latest to take advantage of new features and enhancements, performance improvements, and security options.</p>
+<p>Strimzi can be upgraded to version 0.26.0 to take advantage of new features and enhancements, performance improvements, and security options.</p>
 </div>
 <div class="paragraph">
 <p>As part of the upgrade, you upgrade Kafka to the latest supported version.
@@ -5984,11 +5984,11 @@ Each Kafka release introduces new features, improvements, and bug fixes to your 
 <dl>
 <dt class="hdlist1">Incremental</dt>
 <dd>
-<p>Upgrading Strimzi from the previous minor version to version latest.</p>
+<p>Upgrading Strimzi from the previous minor version to version 0.26.0.</p>
 </dd>
 <dt class="hdlist1">Multi-version</dt>
 <dd>
-<p>Upgrading Strimzi from an old version to version latest within a single upgrade (skipping one or more intermediate versions).</p>
+<p>Upgrading Strimzi from an old version to version 0.26.0 within a single upgrade (skipping one or more intermediate versions).</p>
 <div class="paragraph">
 <p>For example, upgrading from Strimzi 0.20.0 directly to Strimzi 0.22.</p>
 </div>
@@ -6082,7 +6082,7 @@ A reduction in cluster availability increases the chance that a broker failure w
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
-<p>Strimzi latest requires Kubernetes 1.16 and later.</p>
+<p>Strimzi 0.26.0 requires Kubernetes 1.16 and later.</p>
 </div>
 </div>
 </div>
@@ -6324,7 +6324,7 @@ For example, <code>my-cluster-kafka-0</code>.</p>
 <div class="sect2">
 <h3 id="assembly-upgrade-resources-str"><a class="link" href="#assembly-upgrade-resources-str">7.3. Strimzi custom resource upgrades</a></h3>
 <div class="paragraph">
-<p>When upgrading Strimzi to latest from 0.22 or earlier, you must ensure that your custom resources are using API version <code>v1beta2</code>.
+<p>When upgrading Strimzi to 0.26.0 from 0.22 or earlier, you must ensure that your custom resources are using API version <code>v1beta2</code>.
 You must upgrade the Custom Resource Definitions and the custom resources <strong>before</strong> upgrading to Strimzi 0.23 or newer.
 To perform the upgrade, you can use the <em>API conversion tool</em> provided with Strimzi 0.24.
 For more information, see the <a href="https://strimzi.io/docs/operators/0.24.0/deploying.html#assembly-upgrade-resources-str" target="_blank" rel="noopener">Strimzi 0.24.0 upgrade documentation</a>.</p>
@@ -6333,7 +6333,7 @@ For more information, see the <a href="https://strimzi.io/docs/operators/0.24.0/
 <div class="sect2">
 <h3 id="proc-upgrading-the-co-str"><a class="link" href="#proc-upgrading-the-co-str">7.4. Upgrading the Cluster Operator</a></h3>
 <div class="paragraph">
-<p>This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi latest.</p>
+<p>This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi 0.26.0.</p>
 </div>
 <div class="paragraph">
 <p>Follow this procedure if you deployed the Cluster Operator using the installation YAML files rather than <a href="https://operatorhub.io/" target="_blank" rel="noopener">OperatorHub.io</a>.</p>
@@ -6360,7 +6360,7 @@ Refer to the documentation supporting a specific version of Strimzi for informat
 <p>An existing Cluster Operator deployment is available.</p>
 </li>
 <li>
-<p>You have <a href="#downloads-str">downloaded the release artifacts for Strimzi latest</a>.</p>
+<p>You have <a href="#downloads-str">downloaded the release artifacts for Strimzi 0.26.0</a>.</p>
 </li>
 </ul>
 </div>
@@ -6372,7 +6372,7 @@ Refer to the documentation supporting a specific version of Strimzi for informat
 Any changes will be <strong>overwritten</strong> by the new version of the Cluster Operator.</p>
 </li>
 <li>
-<p>Update your custom resources to reflect the supported configuration options available for Strimzi version latest.</p>
+<p>Update your custom resources to reflect the supported configuration options available for Strimzi version 0.26.0.</p>
 </li>
 <li>
 <p>Update the Cluster Operator.</p>
@@ -6460,14 +6460,14 @@ You will upgrade the Kafka version later.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">quay.io/strimzi/kafka:latest-kafka-3.0.0</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code></pre>
 </div>
 </div>
 </li>
 </ol>
 </div>
 <div class="paragraph">
-<p>Your Cluster Operator was upgraded to version latest but the version of Kafka running in the cluster it manages is unchanged.</p>
+<p>Your Cluster Operator was upgraded to version 0.26.0 but the version of Kafka running in the cluster it manages is unchanged.</p>
 </div>
 <div class="paragraph">
 <p>Following the Cluster Operator upgrade, you must perform a <a href="#assembly-upgrading-kafka-versions-str">Kafka upgrade</a>.</p>
@@ -6476,7 +6476,7 @@ You will upgrade the Kafka version later.</p>
 <div class="sect2">
 <h3 id="assembly-upgrading-kafka-versions-str"><a class="link" href="#assembly-upgrading-kafka-versions-str">7.5. Upgrading Kafka</a></h3>
 <div class="paragraph">
-<p>After you have upgraded your Cluster Operator to latest, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.</p>
+<p>After you have upgraded your Cluster Operator to 0.26.0, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.</p>
 </div>
 <div class="paragraph">
 <p>Kafka upgrades are performed by the Cluster Operator through rolling updates of the Kafka brokers.</p>
@@ -7425,7 +7425,7 @@ You must format the value of <code>log.message.format.version</code> and <code>i
 <p>If you are reverting back to a version of Strimzi earlier than 0.22, which uses ZooKeeper for the storage of topic metadata, delete the internal topic store topics from the Kafka cluster.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 </li>
@@ -7446,7 +7446,7 @@ You must format the value of <code>log.message.format.version</code> and <code>i
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-05-13 20:12:43 +0200
+Last updated 2021-11-15 16:59:49 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/0.26.0/full/overview.html
+++ b/docs/operators/0.26.0/full/overview.html
@@ -2079,7 +2079,7 @@ spec:
 <div class="listingblock">
 <div class="title">Example showing manual addition of plugin configuration</div>
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:latest-kafka-3.0.0
+<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -2722,7 +2722,7 @@ A sample configuration file and Grafana dashboard for Cruise Control are provide
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-10-12 23:35:05 +0200
+Last updated 2021-11-15 16:59:49 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/0.26.0/full/quickstart.html
+++ b/docs/operators/0.26.0/full/quickstart.html
@@ -1036,7 +1036,7 @@ EOF</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-05-13 20:12:43 +0200
+Last updated 2021-11-15 16:59:49 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/0.26.0/full/using.html
+++ b/docs/operators/0.26.0/full/using.html
@@ -3301,7 +3301,7 @@ For example, <code>my-cluster-cluster-ca-cert</code>.</p>
 <p>Run a new interactive pod container using the Strimzi Kafka image to connect to a running Kafka broker.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 <em>&lt;interactive_pod_name&gt;</em> -- /bin/sh -c "sleep 3600"</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run --restart=Never --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 <em>&lt;interactive_pod_name&gt;</em> -- /bin/sh -c "sleep 3600"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -11742,7 +11742,7 @@ The truststore is to connect to Keycloak and the Kafka broker.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">NS=sso
-kubectl run -ti --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 kafka-cli -n $NS -- /bin/sh</code></pre>
+kubectl run -ti --restart=Never --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 kafka-cli -n $NS -- /bin/sh</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -12451,12 +12451,12 @@ The label selector applies to <code>Kafka</code>, <code>KafkaConnect</code>, <co
 <p>Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>Kafka.spec.kafka.version</code> property is specified but not the <code>Kafka.spec.kafka.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as default for the init container started before the broker for initial configuration work (that is, rack support), if no image is specified as the <code>kafka-init-image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_CONNECT_IMAGES</code></dt>
@@ -12464,7 +12464,7 @@ The image name to use as default for the init container started before the broke
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>KafkaConnect.spec.version</code> property is specified but not the <code>KafkaConnect.spec.image</code>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_MIRROR_MAKER_IMAGES</code></dt>
@@ -12472,24 +12472,24 @@ This is used when a <code>KafkaConnect.spec.version</code> property is specified
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>KafkaMirrorMaker.spec.version</code> property is specified but not the <code>KafkaMirrorMaker.spec.image</code>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as the default when deploying the topic operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.topicOperator.image</code> in <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as the default when deploying the user operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.userOperator.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+<p>Optional, default <code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the <code>Kafka.spec.entityOperator.tlsSidecar.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
@@ -13767,7 +13767,7 @@ Do not delete these topics, as they are essential to the running of the Topic Op
 The new process removes this requirement, bringing the metadata into the Kafka cluster, and under the control of the Topic Operator.</p>
 </div>
 <div class="paragraph">
-<p>When upgrading to Strimzi latest, the transition to Topic Operator control of the topic store is seamless.
+<p>When upgrading to Strimzi 0.26.0, the transition to Topic Operator control of the topic store is seamless.
 Metadata is found and migrated from ZooKeeper, and the old store is deleted.</p>
 </div>
 </div>
@@ -13784,7 +13784,7 @@ For example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -20715,7 +20715,7 @@ spec:
 <p>Delete the internal topic store topics from the Kafka cluster:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -23123,7 +23123,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23136,7 +23136,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23149,7 +23149,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> container image.</p>
+<p><code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23162,7 +23162,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> container image.</p>
+<p><code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23188,7 +23188,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23201,7 +23201,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_JMXTRANS_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/jmxtrans:latest</code> container image.</p>
+<p><code>quay.io/strimzi/jmxtrans:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23914,7 +23914,7 @@ When the <code>brokerRackInitImage</code> field is missing, the following images
 <p>Container image specified in <code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code> environment variable in the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -36753,7 +36753,7 @@ You can also <a href="#con-common-configuration-ssl-reference">configure the <co
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-05-13 20:12:43 +0200
+Last updated 2021-11-15 17:00:39 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/0.26.0/overview-book.html
+++ b/docs/operators/0.26.0/overview-book.html
@@ -1633,7 +1633,7 @@ spec:
 <div class="listingblock">
 <div class="title">Example showing manual addition of plugin configuration</div>
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:latest-kafka-3.0.0
+<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>

--- a/docs/operators/0.26.0/using-book.html
+++ b/docs/operators/0.26.0/using-book.html
@@ -2855,7 +2855,7 @@ For example, <code>my-cluster-cluster-ca-cert</code>.</p>
 <p>Run a new interactive pod container using the Strimzi Kafka image to connect to a running Kafka broker.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 <em>&lt;interactive_pod_name&gt;</em> -- /bin/sh -c "sleep 3600"</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run --restart=Never --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 <em>&lt;interactive_pod_name&gt;</em> -- /bin/sh -c "sleep 3600"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -11296,7 +11296,7 @@ The truststore is to connect to Keycloak and the Kafka broker.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">NS=sso
-kubectl run -ti --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 kafka-cli -n $NS -- /bin/sh</code></pre>
+kubectl run -ti --restart=Never --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 kafka-cli -n $NS -- /bin/sh</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -12005,12 +12005,12 @@ The label selector applies to <code>Kafka</code>, <code>KafkaConnect</code>, <co
 <p>Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>Kafka.spec.kafka.version</code> property is specified but not the <code>Kafka.spec.kafka.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as default for the init container started before the broker for initial configuration work (that is, rack support), if no image is specified as the <code>kafka-init-image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_CONNECT_IMAGES</code></dt>
@@ -12018,7 +12018,7 @@ The image name to use as default for the init container started before the broke
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>KafkaConnect.spec.version</code> property is specified but not the <code>KafkaConnect.spec.image</code>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_MIRROR_MAKER_IMAGES</code></dt>
@@ -12026,24 +12026,24 @@ This is used when a <code>KafkaConnect.spec.version</code> property is specified
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>KafkaMirrorMaker.spec.version</code> property is specified but not the <code>KafkaMirrorMaker.spec.image</code>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as the default when deploying the topic operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.topicOperator.image</code> in <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as the default when deploying the user operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.userOperator.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+<p>Optional, default <code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the <code>Kafka.spec.entityOperator.tlsSidecar.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
@@ -13321,7 +13321,7 @@ Do not delete these topics, as they are essential to the running of the Topic Op
 The new process removes this requirement, bringing the metadata into the Kafka cluster, and under the control of the Topic Operator.</p>
 </div>
 <div class="paragraph">
-<p>When upgrading to Strimzi latest, the transition to Topic Operator control of the topic store is seamless.
+<p>When upgrading to Strimzi 0.26.0, the transition to Topic Operator control of the topic store is seamless.
 Metadata is found and migrated from ZooKeeper, and the old store is deleted.</p>
 </div>
 </div>
@@ -13338,7 +13338,7 @@ For example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -20269,7 +20269,7 @@ spec:
 <p>Delete the internal topic store topics from the Kafka cluster:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -22677,7 +22677,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22690,7 +22690,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22703,7 +22703,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> container image.</p>
+<p><code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22716,7 +22716,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> container image.</p>
+<p><code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22742,7 +22742,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22755,7 +22755,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_JMXTRANS_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/jmxtrans:latest</code> container image.</p>
+<p><code>quay.io/strimzi/jmxtrans:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23468,7 +23468,7 @@ When the <code>brokerRackInitImage</code> field is missing, the following images
 <p>Container image specified in <code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code> environment variable in the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>

--- a/docs/operators/latest/contributing-book.html
+++ b/docs/operators/latest/contributing-book.html
@@ -2316,7 +2316,7 @@ Fast-forwarded &lt;new-topic-branch&gt; to &lt;user&gt;/&lt;merge-request-branch
 </ol>
 </div>
 <div class="paragraph">
-<p><em>Revised on 2021-10-15 11:27:40 +0200</em></p>
+<p><em>Revised on 2021-11-15 17:04:26 +0100</em></p>
 </div>
 </div>
 </div>

--- a/docs/operators/latest/deploying-book.html
+++ b/docs/operators/latest/deploying-book.html
@@ -883,7 +883,7 @@ Example configuration files for custom resources contain important properties an
 </div>
 <div class="paragraph">
 <p>You can also access the example files directly from the
-<a href="https://github.com/strimzi/strimzi-kafka-operator/tree/main/examples/" target="_blank" rel="noopener"><code>examples</code> directory</a>.</p>
+<a href="https://github.com/strimzi/strimzi-kafka-operator/tree/0.26.0/examples/" target="_blank" rel="noopener"><code>examples</code> directory</a>.</p>
 </div>
 <div class="paragraph">
 <p>You can download and apply the examples using the <code>kubectl</code> command-line tool.
@@ -1019,13 +1019,13 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-2.8.0</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-2.8.0</p>
 </li>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-2.8.1</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-2.8.1</p>
 </li>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-3.0.0</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1057,7 +1057,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/operator:latest</p>
+<p>quay.io/strimzi/operator:0.26.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1099,7 +1099,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/jmxtrans:latest</p>
+<p>quay.io/strimzi/jmxtrans:0.26.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1536,7 +1536,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: quay.io/strimzi/operator:latest
+        image: quay.io/strimzi/operator:0.26.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -1632,7 +1632,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: quay.io/strimzi/operator:latest
+        image: quay.io/strimzi/operator:0.26.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -2868,10 +2868,10 @@ spec: # <b class="conum">(1)</b>
 <div class="title">Procedure</div>
 <ol class="arabic">
 <li>
-<p>Create a new <code>Dockerfile</code> using <code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> as the base image:</p>
+<p>Create a new <code>Dockerfile</code> using <code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> as the base image:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:latest-kafka-3.0.0
+<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -3699,7 +3699,7 @@ and require familiarity with the <a href="./using.html#assembly-deployment-confi
 <p>Deploy a Kafka producer.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
 </div>
 </div>
 </li>
@@ -3713,7 +3713,7 @@ and require familiarity with the <a href="./using.html#assembly-deployment-confi
 <p>Deploy a Kafka consumer.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
 </div>
 </div>
 </li>
@@ -5521,7 +5521,7 @@ The name of the Grafana pod is different for each user.</p>
 <h2 id="assembly-upgrade-str"><a class="link" href="#assembly-upgrade-str">7. Upgrading Strimzi</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Strimzi can be upgraded to version latest to take advantage of new features and enhancements, performance improvements, and security options.</p>
+<p>Strimzi can be upgraded to version 0.26.0 to take advantage of new features and enhancements, performance improvements, and security options.</p>
 </div>
 <div class="paragraph">
 <p>As part of the upgrade, you upgrade Kafka to the latest supported version.
@@ -5538,11 +5538,11 @@ Each Kafka release introduces new features, improvements, and bug fixes to your 
 <dl>
 <dt class="hdlist1">Incremental</dt>
 <dd>
-<p>Upgrading Strimzi from the previous minor version to version latest.</p>
+<p>Upgrading Strimzi from the previous minor version to version 0.26.0.</p>
 </dd>
 <dt class="hdlist1">Multi-version</dt>
 <dd>
-<p>Upgrading Strimzi from an old version to version latest within a single upgrade (skipping one or more intermediate versions).</p>
+<p>Upgrading Strimzi from an old version to version 0.26.0 within a single upgrade (skipping one or more intermediate versions).</p>
 <div class="paragraph">
 <p>For example, upgrading from Strimzi 0.20.0 directly to Strimzi 0.22.</p>
 </div>
@@ -5636,7 +5636,7 @@ A reduction in cluster availability increases the chance that a broker failure w
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
-<p>Strimzi latest requires Kubernetes 1.16 and later.</p>
+<p>Strimzi 0.26.0 requires Kubernetes 1.16 and later.</p>
 </div>
 </div>
 </div>
@@ -5878,7 +5878,7 @@ For example, <code>my-cluster-kafka-0</code>.</p>
 <div class="sect2">
 <h3 id="assembly-upgrade-resources-str"><a class="link" href="#assembly-upgrade-resources-str">7.3. Strimzi custom resource upgrades</a></h3>
 <div class="paragraph">
-<p>When upgrading Strimzi to latest from 0.22 or earlier, you must ensure that your custom resources are using API version <code>v1beta2</code>.
+<p>When upgrading Strimzi to 0.26.0 from 0.22 or earlier, you must ensure that your custom resources are using API version <code>v1beta2</code>.
 You must upgrade the Custom Resource Definitions and the custom resources <strong>before</strong> upgrading to Strimzi 0.23 or newer.
 To perform the upgrade, you can use the <em>API conversion tool</em> provided with Strimzi 0.24.
 For more information, see the <a href="https://strimzi.io/docs/operators/0.24.0/deploying.html#assembly-upgrade-resources-str" target="_blank" rel="noopener">Strimzi 0.24.0 upgrade documentation</a>.</p>
@@ -5887,7 +5887,7 @@ For more information, see the <a href="https://strimzi.io/docs/operators/0.24.0/
 <div class="sect2">
 <h3 id="proc-upgrading-the-co-str"><a class="link" href="#proc-upgrading-the-co-str">7.4. Upgrading the Cluster Operator</a></h3>
 <div class="paragraph">
-<p>This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi latest.</p>
+<p>This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi 0.26.0.</p>
 </div>
 <div class="paragraph">
 <p>Follow this procedure if you deployed the Cluster Operator using the installation YAML files rather than <a href="https://operatorhub.io/" target="_blank" rel="noopener">OperatorHub.io</a>.</p>
@@ -5914,7 +5914,7 @@ Refer to the documentation supporting a specific version of Strimzi for informat
 <p>An existing Cluster Operator deployment is available.</p>
 </li>
 <li>
-<p>You have <a href="#downloads-str">downloaded the release artifacts for Strimzi latest</a>.</p>
+<p>You have <a href="#downloads-str">downloaded the release artifacts for Strimzi 0.26.0</a>.</p>
 </li>
 </ul>
 </div>
@@ -5926,7 +5926,7 @@ Refer to the documentation supporting a specific version of Strimzi for informat
 Any changes will be <strong>overwritten</strong> by the new version of the Cluster Operator.</p>
 </li>
 <li>
-<p>Update your custom resources to reflect the supported configuration options available for Strimzi version latest.</p>
+<p>Update your custom resources to reflect the supported configuration options available for Strimzi version 0.26.0.</p>
 </li>
 <li>
 <p>Update the Cluster Operator.</p>
@@ -6014,14 +6014,14 @@ You will upgrade the Kafka version later.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">quay.io/strimzi/kafka:latest-kafka-3.0.0</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code></pre>
 </div>
 </div>
 </li>
 </ol>
 </div>
 <div class="paragraph">
-<p>Your Cluster Operator was upgraded to version latest but the version of Kafka running in the cluster it manages is unchanged.</p>
+<p>Your Cluster Operator was upgraded to version 0.26.0 but the version of Kafka running in the cluster it manages is unchanged.</p>
 </div>
 <div class="paragraph">
 <p>Following the Cluster Operator upgrade, you must perform a <a href="#assembly-upgrading-kafka-versions-str">Kafka upgrade</a>.</p>
@@ -6030,7 +6030,7 @@ You will upgrade the Kafka version later.</p>
 <div class="sect2">
 <h3 id="assembly-upgrading-kafka-versions-str"><a class="link" href="#assembly-upgrading-kafka-versions-str">7.5. Upgrading Kafka</a></h3>
 <div class="paragraph">
-<p>After you have upgraded your Cluster Operator to latest, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.</p>
+<p>After you have upgraded your Cluster Operator to 0.26.0, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.</p>
 </div>
 <div class="paragraph">
 <p>Kafka upgrades are performed by the Cluster Operator through rolling updates of the Kafka brokers.</p>
@@ -6979,7 +6979,7 @@ You must format the value of <code>log.message.format.version</code> and <code>i
 <p>If you are reverting back to a version of Strimzi earlier than 0.22, which uses ZooKeeper for the storage of topic metadata, delete the internal topic store topics from the Kafka cluster.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 </li>

--- a/docs/operators/latest/full/contributing.html
+++ b/docs/operators/latest/full/contributing.html
@@ -2762,7 +2762,7 @@ Fast-forwarded &lt;new-topic-branch&gt; to &lt;user&gt;/&lt;merge-request-branch
 </ol>
 </div>
 <div class="paragraph">
-<p><em>Revised on 2021-10-15 11:27:33 +0200</em></p>
+<p><em>Revised on 2021-11-15 17:04:43 +0100</em></p>
 </div>
 </div>
 </div>
@@ -2770,7 +2770,7 @@ Fast-forwarded &lt;new-topic-branch&gt; to &lt;user&gt;/&lt;merge-request-branch
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-05-13 20:12:43 +0200
+Last updated 2021-11-15 16:59:49 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/latest/full/deploying.html
+++ b/docs/operators/latest/full/deploying.html
@@ -1329,7 +1329,7 @@ Example configuration files for custom resources contain important properties an
 </div>
 <div class="paragraph">
 <p>You can also access the example files directly from the
-<a href="https://github.com/strimzi/strimzi-kafka-operator/tree/main/examples/" target="_blank" rel="noopener"><code>examples</code> directory</a>.</p>
+<a href="https://github.com/strimzi/strimzi-kafka-operator/tree/0.26.0/examples/" target="_blank" rel="noopener"><code>examples</code> directory</a>.</p>
 </div>
 <div class="paragraph">
 <p>You can download and apply the examples using the <code>kubectl</code> command-line tool.
@@ -1465,13 +1465,13 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-2.8.0</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-2.8.0</p>
 </li>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-2.8.1</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-2.8.1</p>
 </li>
 <li>
-<p>quay.io/strimzi/kafka:latest-kafka-3.0.0</p>
+<p>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1503,7 +1503,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/operator:latest</p>
+<p>quay.io/strimzi/operator:0.26.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1545,7 +1545,7 @@ Each Kafka version supported for the release has a separate image.
 <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
 <ul>
 <li>
-<p>quay.io/strimzi/jmxtrans:latest</p>
+<p>quay.io/strimzi/jmxtrans:0.26.0</p>
 </li>
 </ul>
 </div></div></td>
@@ -1982,7 +1982,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: quay.io/strimzi/operator:latest
+        image: quay.io/strimzi/operator:0.26.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -2078,7 +2078,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: quay.io/strimzi/operator:latest
+        image: quay.io/strimzi/operator:0.26.0
         imagePullPolicy: IfNotPresent
         env:
         - name: STRIMZI_NAMESPACE
@@ -3314,10 +3314,10 @@ spec: # <b class="conum">(1)</b>
 <div class="title">Procedure</div>
 <ol class="arabic">
 <li>
-<p>Create a new <code>Dockerfile</code> using <code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> as the base image:</p>
+<p>Create a new <code>Dockerfile</code> using <code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> as the base image:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:latest-kafka-3.0.0
+<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -4145,7 +4145,7 @@ and require familiarity with the <a href="./using.html#assembly-deployment-confi
 <p>Deploy a Kafka producer.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-producer -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em></code></pre>
 </div>
 </div>
 </li>
@@ -4159,7 +4159,7 @@ and require familiarity with the <a href="./using.html#assembly-deployment-confi
 <p>Deploy a Kafka consumer.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-consumer -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server <em>cluster-name</em>-kafka-bootstrap:9092 --topic <em>my-topic</em> --from-beginning</code></pre>
 </div>
 </div>
 </li>
@@ -5967,7 +5967,7 @@ The name of the Grafana pod is different for each user.</p>
 <h2 id="assembly-upgrade-str"><a class="link" href="#assembly-upgrade-str">7. Upgrading Strimzi</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Strimzi can be upgraded to version latest to take advantage of new features and enhancements, performance improvements, and security options.</p>
+<p>Strimzi can be upgraded to version 0.26.0 to take advantage of new features and enhancements, performance improvements, and security options.</p>
 </div>
 <div class="paragraph">
 <p>As part of the upgrade, you upgrade Kafka to the latest supported version.
@@ -5984,11 +5984,11 @@ Each Kafka release introduces new features, improvements, and bug fixes to your 
 <dl>
 <dt class="hdlist1">Incremental</dt>
 <dd>
-<p>Upgrading Strimzi from the previous minor version to version latest.</p>
+<p>Upgrading Strimzi from the previous minor version to version 0.26.0.</p>
 </dd>
 <dt class="hdlist1">Multi-version</dt>
 <dd>
-<p>Upgrading Strimzi from an old version to version latest within a single upgrade (skipping one or more intermediate versions).</p>
+<p>Upgrading Strimzi from an old version to version 0.26.0 within a single upgrade (skipping one or more intermediate versions).</p>
 <div class="paragraph">
 <p>For example, upgrading from Strimzi 0.20.0 directly to Strimzi 0.22.</p>
 </div>
@@ -6082,7 +6082,7 @@ A reduction in cluster availability increases the chance that a broker failure w
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
-<p>Strimzi latest requires Kubernetes 1.16 and later.</p>
+<p>Strimzi 0.26.0 requires Kubernetes 1.16 and later.</p>
 </div>
 </div>
 </div>
@@ -6324,7 +6324,7 @@ For example, <code>my-cluster-kafka-0</code>.</p>
 <div class="sect2">
 <h3 id="assembly-upgrade-resources-str"><a class="link" href="#assembly-upgrade-resources-str">7.3. Strimzi custom resource upgrades</a></h3>
 <div class="paragraph">
-<p>When upgrading Strimzi to latest from 0.22 or earlier, you must ensure that your custom resources are using API version <code>v1beta2</code>.
+<p>When upgrading Strimzi to 0.26.0 from 0.22 or earlier, you must ensure that your custom resources are using API version <code>v1beta2</code>.
 You must upgrade the Custom Resource Definitions and the custom resources <strong>before</strong> upgrading to Strimzi 0.23 or newer.
 To perform the upgrade, you can use the <em>API conversion tool</em> provided with Strimzi 0.24.
 For more information, see the <a href="https://strimzi.io/docs/operators/0.24.0/deploying.html#assembly-upgrade-resources-str" target="_blank" rel="noopener">Strimzi 0.24.0 upgrade documentation</a>.</p>
@@ -6333,7 +6333,7 @@ For more information, see the <a href="https://strimzi.io/docs/operators/0.24.0/
 <div class="sect2">
 <h3 id="proc-upgrading-the-co-str"><a class="link" href="#proc-upgrading-the-co-str">7.4. Upgrading the Cluster Operator</a></h3>
 <div class="paragraph">
-<p>This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi latest.</p>
+<p>This procedure describes how to upgrade a Cluster Operator deployment to use Strimzi 0.26.0.</p>
 </div>
 <div class="paragraph">
 <p>Follow this procedure if you deployed the Cluster Operator using the installation YAML files rather than <a href="https://operatorhub.io/" target="_blank" rel="noopener">OperatorHub.io</a>.</p>
@@ -6360,7 +6360,7 @@ Refer to the documentation supporting a specific version of Strimzi for informat
 <p>An existing Cluster Operator deployment is available.</p>
 </li>
 <li>
-<p>You have <a href="#downloads-str">downloaded the release artifacts for Strimzi latest</a>.</p>
+<p>You have <a href="#downloads-str">downloaded the release artifacts for Strimzi 0.26.0</a>.</p>
 </li>
 </ul>
 </div>
@@ -6372,7 +6372,7 @@ Refer to the documentation supporting a specific version of Strimzi for informat
 Any changes will be <strong>overwritten</strong> by the new version of the Cluster Operator.</p>
 </li>
 <li>
-<p>Update your custom resources to reflect the supported configuration options available for Strimzi version latest.</p>
+<p>Update your custom resources to reflect the supported configuration options available for Strimzi version 0.26.0.</p>
 </li>
 <li>
 <p>Update the Cluster Operator.</p>
@@ -6460,14 +6460,14 @@ You will upgrade the Kafka version later.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">quay.io/strimzi/kafka:latest-kafka-3.0.0</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code></pre>
 </div>
 </div>
 </li>
 </ol>
 </div>
 <div class="paragraph">
-<p>Your Cluster Operator was upgraded to version latest but the version of Kafka running in the cluster it manages is unchanged.</p>
+<p>Your Cluster Operator was upgraded to version 0.26.0 but the version of Kafka running in the cluster it manages is unchanged.</p>
 </div>
 <div class="paragraph">
 <p>Following the Cluster Operator upgrade, you must perform a <a href="#assembly-upgrading-kafka-versions-str">Kafka upgrade</a>.</p>
@@ -6476,7 +6476,7 @@ You will upgrade the Kafka version later.</p>
 <div class="sect2">
 <h3 id="assembly-upgrading-kafka-versions-str"><a class="link" href="#assembly-upgrading-kafka-versions-str">7.5. Upgrading Kafka</a></h3>
 <div class="paragraph">
-<p>After you have upgraded your Cluster Operator to latest, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.</p>
+<p>After you have upgraded your Cluster Operator to 0.26.0, the next step is to upgrade all Kafka brokers to the latest supported version of Kafka.</p>
 </div>
 <div class="paragraph">
 <p>Kafka upgrades are performed by the Cluster Operator through rolling updates of the Kafka brokers.</p>
@@ -7425,7 +7425,7 @@ You must format the value of <code>log.message.format.version</code> and <code>i
 <p>If you are reverting back to a version of Strimzi earlier than 0.22, which uses ZooKeeper for the storage of topic metadata, delete the internal topic store topics from the Kafka cluster.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 </li>
@@ -7446,7 +7446,7 @@ You must format the value of <code>log.message.format.version</code> and <code>i
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-05-13 20:12:43 +0200
+Last updated 2021-11-15 16:59:49 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/latest/full/overview.html
+++ b/docs/operators/latest/full/overview.html
@@ -2079,7 +2079,7 @@ spec:
 <div class="listingblock">
 <div class="title">Example showing manual addition of plugin configuration</div>
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:latest-kafka-3.0.0
+<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>
@@ -2722,7 +2722,7 @@ A sample configuration file and Grafana dashboard for Cruise Control are provide
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-10-12 23:35:05 +0200
+Last updated 2021-11-15 16:59:49 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/latest/full/quickstart.html
+++ b/docs/operators/latest/full/quickstart.html
@@ -1036,7 +1036,7 @@ EOF</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-05-13 20:12:43 +0200
+Last updated 2021-11-15 16:59:49 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/latest/full/using.html
+++ b/docs/operators/latest/full/using.html
@@ -3301,7 +3301,7 @@ For example, <code>my-cluster-cluster-ca-cert</code>.</p>
 <p>Run a new interactive pod container using the Strimzi Kafka image to connect to a running Kafka broker.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 <em>&lt;interactive_pod_name&gt;</em> -- /bin/sh -c "sleep 3600"</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run --restart=Never --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 <em>&lt;interactive_pod_name&gt;</em> -- /bin/sh -c "sleep 3600"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -11742,7 +11742,7 @@ The truststore is to connect to Keycloak and the Kafka broker.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">NS=sso
-kubectl run -ti --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 kafka-cli -n $NS -- /bin/sh</code></pre>
+kubectl run -ti --restart=Never --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 kafka-cli -n $NS -- /bin/sh</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -12451,12 +12451,12 @@ The label selector applies to <code>Kafka</code>, <code>KafkaConnect</code>, <co
 <p>Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>Kafka.spec.kafka.version</code> property is specified but not the <code>Kafka.spec.kafka.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as default for the init container started before the broker for initial configuration work (that is, rack support), if no image is specified as the <code>kafka-init-image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_CONNECT_IMAGES</code></dt>
@@ -12464,7 +12464,7 @@ The image name to use as default for the init container started before the broke
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>KafkaConnect.spec.version</code> property is specified but not the <code>KafkaConnect.spec.image</code>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_MIRROR_MAKER_IMAGES</code></dt>
@@ -12472,24 +12472,24 @@ This is used when a <code>KafkaConnect.spec.version</code> property is specified
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>KafkaMirrorMaker.spec.version</code> property is specified but not the <code>KafkaMirrorMaker.spec.image</code>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as the default when deploying the topic operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.topicOperator.image</code> in <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as the default when deploying the user operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.userOperator.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+<p>Optional, default <code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the <code>Kafka.spec.entityOperator.tlsSidecar.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
@@ -13767,7 +13767,7 @@ Do not delete these topics, as they are essential to the running of the Topic Op
 The new process removes this requirement, bringing the metadata into the Kafka cluster, and under the control of the Topic Operator.</p>
 </div>
 <div class="paragraph">
-<p>When upgrading to Strimzi latest, the transition to Topic Operator control of the topic store is seamless.
+<p>When upgrading to Strimzi 0.26.0, the transition to Topic Operator control of the topic store is seamless.
 Metadata is found and migrated from ZooKeeper, and the old store is deleted.</p>
 </div>
 </div>
@@ -13784,7 +13784,7 @@ For example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -20715,7 +20715,7 @@ spec:
 <p>Delete the internal topic store topics from the Kafka cluster:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -23123,7 +23123,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23136,7 +23136,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23149,7 +23149,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> container image.</p>
+<p><code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23162,7 +23162,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> container image.</p>
+<p><code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23188,7 +23188,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23201,7 +23201,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_JMXTRANS_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/jmxtrans:latest</code> container image.</p>
+<p><code>quay.io/strimzi/jmxtrans:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23914,7 +23914,7 @@ When the <code>brokerRackInitImage</code> field is missing, the following images
 <p>Container image specified in <code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code> environment variable in the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -36753,7 +36753,7 @@ You can also <a href="#con-common-configuration-ssl-reference">configure the <co
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-05-13 20:12:43 +0200
+Last updated 2021-11-15 17:00:39 +0100
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/docs/operators/latest/overview-book.html
+++ b/docs/operators/latest/overview-book.html
@@ -1633,7 +1633,7 @@ spec:
 <div class="listingblock">
 <div class="title">Example showing manual addition of plugin configuration</div>
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:latest-kafka-3.0.0
+<pre class="highlightjs highlight"><code class="language-none hljs">FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
 USER root:root
 COPY ./<em>my-plugins</em>/ /opt/kafka/plugins/
 USER 1001</code></pre>

--- a/docs/operators/latest/using-book.html
+++ b/docs/operators/latest/using-book.html
@@ -2855,7 +2855,7 @@ For example, <code>my-cluster-cluster-ca-cert</code>.</p>
 <p>Run a new interactive pod container using the Strimzi Kafka image to connect to a running Kafka broker.</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 <em>&lt;interactive_pod_name&gt;</em> -- /bin/sh -c "sleep 3600"</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run --restart=Never --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 <em>&lt;interactive_pod_name&gt;</em> -- /bin/sh -c "sleep 3600"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -11296,7 +11296,7 @@ The truststore is to connect to Keycloak and the Kafka broker.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">NS=sso
-kubectl run -ti --restart=Never --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 kafka-cli -n $NS -- /bin/sh</code></pre>
+kubectl run -ti --restart=Never --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 kafka-cli -n $NS -- /bin/sh</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -12005,12 +12005,12 @@ The label selector applies to <code>Kafka</code>, <code>KafkaConnect</code>, <co
 <p>Required.
 This provides a mapping from Kafka version to the corresponding Docker image containing a Kafka broker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>Kafka.spec.kafka.version</code> property is specified but not the <code>Kafka.spec.kafka.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as default for the init container started before the broker for initial configuration work (that is, rack support), if no image is specified as the <code>kafka-init-image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_CONNECT_IMAGES</code></dt>
@@ -12018,7 +12018,7 @@ The image name to use as default for the init container started before the broke
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka connect of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>KafkaConnect.spec.version</code> property is specified but not the <code>KafkaConnect.spec.image</code>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_KAFKA_MIRROR_MAKER_IMAGES</code></dt>
@@ -12026,24 +12026,24 @@ This is used when a <code>KafkaConnect.spec.version</code> property is specified
 <p>Required.
 This provides a mapping from the Kafka version to the corresponding Docker image containing a Kafka mirror maker of that version.
 The required syntax is whitespace or comma separated <code><em>&lt;version&gt;</em>=<em>&lt;image&gt;</em></code> pairs.
-For example <code>2.8.0=quay.io/strimzi/kafka:latest-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+For example <code>2.8.0=quay.io/strimzi/kafka:0.26.0-kafka-2.8.0, 3.0.0=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 This is used when a <code>KafkaMirrorMaker.spec.version</code> property is specified but not the <code>KafkaMirrorMaker.spec.image</code>.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as the default when deploying the topic operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.topicOperator.image</code> in <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/operator:latest</code>.
+<p>Optional, default <code>quay.io/strimzi/operator:0.26.0</code>.
 The image name to use as the default when deploying the user operator,
 if no image is specified as the <code>Kafka.spec.entityOperator.userOperator.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
 <dt class="hdlist1"><code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code></dt>
 <dd>
-<p>Optional, default <code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code>.
+<p>Optional, default <code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code>.
 The image name to use as the default when deploying the sidecar container which provides TLS support for the Entity Operator, if
 no image is specified as the <code>Kafka.spec.entityOperator.tlsSidecar.image</code> in the <code>Kafka</code> resource.</p>
 </dd>
@@ -13321,7 +13321,7 @@ Do not delete these topics, as they are essential to the running of the Topic Op
 The new process removes this requirement, bringing the metadata into the Kafka cluster, and under the control of the Topic Operator.</p>
 </div>
 <div class="paragraph">
-<p>When upgrading to Strimzi latest, the transition to Topic Operator control of the topic store is seamless.
+<p>When upgrading to Strimzi 0.26.0, the transition to Topic Operator control of the topic store is seamless.
 Metadata is found and migrated from ZooKeeper, and the old store is deleted.</p>
 </div>
 </div>
@@ -13338,7 +13338,7 @@ For example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -20269,7 +20269,7 @@ spec:
 <p>Delete the internal topic store topics from the Kafka cluster:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:latest-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
+<pre class="highlightjs highlight"><code class="language-shell hljs" data-lang="shell">kubectl run kafka-admin -ti --image=quay.io/strimzi/kafka:0.26.0-kafka-3.0.0 --rm=true --restart=Never -- ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi-topic-operator-kstreams-topic-store-changelog --delete &amp;&amp; ./bin/kafka-topics.sh --bootstrap-server localhost:9092 --topic __strimzi_store_topic --delete</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -22677,7 +22677,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22690,7 +22690,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_USER_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22703,7 +22703,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> container image.</p>
+<p><code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22716,7 +22716,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/kafka:latest-kafka-3.0.0</code> container image.</p>
+<p><code>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22742,7 +22742,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -22755,7 +22755,7 @@ If the <code>image</code> name is not defined in the Cluster Operator configurat
 <p>Container image specified in the <code>STRIMZI_DEFAULT_JMXTRANS_IMAGE</code> environment variable from the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/jmxtrans:latest</code> container image.</p>
+<p><code>quay.io/strimzi/jmxtrans:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>
@@ -23468,7 +23468,7 @@ When the <code>brokerRackInitImage</code> field is missing, the following images
 <p>Container image specified in <code>STRIMZI_DEFAULT_KAFKA_INIT_IMAGE</code> environment variable in the Cluster Operator configuration.</p>
 </li>
 <li>
-<p><code>quay.io/strimzi/operator:latest</code> container image.</p>
+<p><code>quay.io/strimzi/operator:0.26.0</code> container image.</p>
 </li>
 </ol>
 </div>


### PR DESCRIPTION
It looks like the docs for the 0.26.0 release were rendered without the proper `ProductVersion` variable and use therefore on many places `latest` instead of `0.26.0`. This PR updates the docs with a properly rendered version.