### PR TITLE
Define a blog post process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+### Type of change
+
+_Select the type of your PR_
+
+* [ ] Typo/minor fix
+* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
+* [ ] Other

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In order to build and serve the web site locally, run :
 
 We try to use the following process for blog posts:
 
-1. You should start by [asking us](https://strimzi.io//join-us/#ask-for-help-and-help-others) whether your proposed subject is a good fit for the strimzi.io blog.
+1. You should start by [asking us](https://strimzi.io/join-us/#ask-for-help-and-help-others) whether your proposed subject is a good fit for the strimzi.io blog.
    The aim of this step is to prevent you wasting your time writing a post which isn't going to interest Strimzi users.
    If your proposal is not perfect from the off, we might suggest ways to make it more relevent to our audience.
    Even if we don't think it will be relevant we might be able to recommend a better site for your proposed content.

--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ In order to build and serve the web site locally, run :
 
 ## Blog posts
 
-To start a new blog post, just create a new file in the `_posts` subdirectory and name it `<date>-<title>.md`. 
-For the date, you can use the current date. 
-After your blog post is reviewed and approved, we will change it to the actual publishing date when merging the PR. 
-
 We try to use the following process for blog posts:
 
-1. You should start by [asking us](/join-us/#ask-for-help-and-help-others) whether your proposed subject is a good fit for the strimzi.io blog.
+1. You should start by [asking us](https://strimzi.io//join-us/#ask-for-help-and-help-others) whether your proposed subject is a good fit for the strimzi.io blog.
    The aim of this step is to prevent you wasting your time writing a post which isn't going to interest Strimzi users.
-   If your proposal is not perfect from the off, or we might suggest ways to make it more relevent to our audience.
+   If your proposal is not perfect from the off, we might suggest ways to make it more relevent to our audience.
    Even if we don't think it will be relevant we might be able to recommend a better site for your proposed content.
    
 2. You write your post and open a PR.
+   To start a new blog post, just create a new file in the `_posts` subdirectory and name it `<date>-<title>.md`. 
+   For the date, you can use the current date (after your blog post is reviewed and approved, we will change it to the actual publishing date when merging the PR). 
+   See [this blog post](https://strimzi.io/blog/2021/07/29/how-to-write-blog-posts-for-strimzi-blog/) for a detailed overview of the mechanics of writing a blog post.
+
 3. We'll do a content review, checking for technical accuracy, logical structure etc.
    Sometimes this can be an iterative process, but we'll try not to keep you waiting. 
+   
 4. Once the content is good we'll do a final review pass focussing on things like spelling and grammar.
    Don't worry if you're not a native English speaker; our main intent here isn't necessarily _perfect_ English, but to ensure the content is easily understood.
 
-See [this blog post](http://127.0.0.1:4000/blog/2021/07/29/how-to-write-blog-posts-for-strimzi-blog/) for a detailed overview of the mechanics of writing a blog post.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,24 @@ In order to build and serve the web site locally, run :
 
     bundle install
     bundle exec jekyll serve
+
+## Blog posts
+
+To start a new blog post, just create a new file in the `_posts` subdirectory and name it `<date>-<title>.md`. 
+For the date, you can use the current date. 
+After your blog post is reviewed and approved, we will change it to the actual publishing date when merging the PR. 
+
+We try to use the following process for blog posts:
+
+1. You should start by [asking us](/join-us/#ask-for-help-and-help-others) whether your proposed subject is a good fit for the strimzi.io blog.
+   The aim of this step is to prevent you wasting your time writing a post which isn't going to interest Strimzi users.
+   If your proposal is not perfect from the off, or we might suggest ways to make it more relevent to our audience.
+   Even if we don't think it will be relevant we might be able to recommend a better site for your proposed content.
+   
+2. You write your post and open a PR.
+3. We'll do a content review, checking for technical accuracy, logical structure etc.
+   Sometimes this can be an iterative process, but we'll try not to keep you waiting. 
+4. Once the content is good we'll do a final review pass focussing on things like spelling and grammar.
+   Don't worry if you're not a native English speaker; our main intent here isn't necessarily _perfect_ English, but to ensure the content is easily understood.
+
+See [this blog post](http://127.0.0.1:4000/blog/2021/07/29/how-to-write-blog-posts-for-strimzi-blog/) for a detailed overview of the mechanics of writing a blog post.


### PR DESCRIPTION
* Try to set expectations for people wanting to blog by defining a process. 
* Use a very basic PR template referencing the README (considered using [named PR template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository), but there's doesn't seem to be a way to have people say "this is a blog post PR" when opening a PR, just the `template` query parameter).

Signed-off-by: Tom Bentley <tbentley@redhat.com>