### PR TITLE
Add "Everything you ever needed to know about Kafka on Kubernetes but were afraid to ask" talk to presentations

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -19,6 +19,10 @@ strimzi_presentations:
    info: OpenShift Commons
    video_url: https://www.youtube.com/watch?v=Ox11Wo1RANI
    slides_url: https://www.slideshare.net/paolopat/finding-a-workload-balance-cruise-control-for-kafka-on-kubernetes
+ - name: Everything you ever needed to know about Kafka on Kubernetes but were afraid to ask
+   info: Kafka Summit 2021
+   video_url: https://www.confluent.io/events/kafka-summit-europe-2021/everything-you-ever-needed-to-know-about-kafka-on-kubernetes-but-were-afraid/
+   slides_url: https://www.slideshare.net/HostedbyConfluent/everything-you-ever-needed-to-know-about-kafka-on-kubernetes-but-were-afraid-to-ask-jakub-scholz-red-hat
  - name: Apache Kafka as a Monitoring Data Pipeline
    info: DevConf.CZ 2021
    video_url: https://youtu.be/BcpS_6yC1S0


### PR DESCRIPTION
This PR adds the "Everything you ever needed to know about Kafka on Kubernetes but were afraid to ask" conference talk from Kafka Summit to presentations site.