### PR TITLE
Add footnote about CRD v1beta1 support in the table with supported versions

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -93,6 +93,7 @@ operator:
     oAuthVersion: 0.7.1
     kafkaVersions: 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.7.0
     kubernetesVersions: 1.16+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -104,6 +105,7 @@ operator:
     oAuthVersion: 0.7.1
     kafkaVersions: 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.7.0
     kubernetesVersions: 1.16+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -115,6 +117,7 @@ operator:
     oAuthVersion: 0.6.1
     kafkaVersions: 2.5.0, 2.5.1, 2.6.0, 2.7.0
     kubernetesVersions: 1.16+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -126,6 +129,7 @@ operator:
     oAuthVersion: 0.6.1
     kafkaVersions: 2.5.0, 2.5.1, 2.6.0, 2.7.0
     kubernetesVersions: 1.16+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -137,6 +141,7 @@ operator:
     oAuthVersion: 0.6.1
     kafkaVersions: 2.5.0, 2.5.1, 2.6.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -148,6 +153,7 @@ operator:
     oAuthVersion: 0.6.1
     kafkaVersions: 2.5.0, 2.5.1, 2.6.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -159,6 +165,7 @@ operator:
     oAuthVersion: 0.5.0
     kafkaVersions: 2.4.0, 2.4.1, 2.5.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -170,6 +177,7 @@ operator:
     oAuthVersion: 0.5.0
     kafkaVersions: 2.4.0, 2.4.1, 2.5.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -181,6 +189,7 @@ operator:
     oAuthVersion: 0.3.0
     kafkaVersions: 2.3.1, 2.4.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -192,6 +201,7 @@ operator:
     oAuthVersion: 0.2.0
     kafkaVersions: 2.3.1, 2.4.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -202,6 +212,7 @@ operator:
     oAuthVersion: 0.2.0
     kafkaVersions: 2.3.1, 2.4.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -212,6 +223,7 @@ operator:
     oAuthVersion: 0.2.0
     kafkaVersions: 2.3.1, 2.4.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -222,6 +234,7 @@ operator:
     oAuthVersion: 0.1.0
     kafkaVersions: 2.2.1, 2.3.0, 2.3.1
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: false
     quickstart_book: true
     using_book: true
@@ -233,6 +246,7 @@ operator:
     oAuthVersion: 0.1.0
     kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1, 2.3.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: false
     quickstart_book: false
     using_book: true
@@ -243,6 +257,7 @@ operator:
     bridgeVersion: 0.13.0
     kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1, 2.3.0
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: false
     quickstart_book: false
     using_book: true
@@ -253,6 +268,7 @@ operator:
     bridgeVersion: 0.12.2
     kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: false
     quickstart_book: false
     using_book: true
@@ -263,6 +279,7 @@ operator:
     bridgeVersion: 0.12.1
     kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: false
     quickstart_book: false
     using_book: true
@@ -273,6 +290,7 @@ operator:
     bridgeVersion: 0.12.0
     kafkaVersions: 2.1.0, 2.1.1, 2.2.0, 2.2.1
     kubernetesVersions: 1.11+
+    usesCrdV1Beta1: true
     overview_book: false
     quickstart_book: false
     using_book: true

--- a/_includes/downloads/supported-versions-band.html
+++ b/_includes/downloads/supported-versions-band.html
@@ -41,11 +41,16 @@
           <td class="version">{% if oRelease.bridgeVersion %}<a href="https://github.com/strimzi/strimzi-kafka-bridge/releases/tag/{{oRelease.bridgeVersion}}">{{oRelease.bridgeVersion}}</a>{% endif %}</td>
           <td class="version">{% if oRelease.oAuthVersion %}<a href="https://github.com/strimzi/strimzi-kafka-oauth/releases/tag/{{oRelease.oAuthVersion}}">{{oRelease.oAuthVersion}}</a>{% else %}n/a{% endif %}</td>
           <td class="version">{% if oRelease.kafkaVersions %}{{oRelease.kafkaVersions}}{% endif %}</td>
-          <td class="version">{% if oRelease.kubernetesVersions %}{{oRelease.kubernetesVersions}}{% endif %}</td>
+          <td class="version">{% if oRelease.kubernetesVersions %}{{oRelease.kubernetesVersions}}{% endif %}{% if oRelease.usesCrdV1Beta1 %} <sup><a href="#crd-v1beta1-support">1</a></sup>{% endif %}</td>
         </tr>
           {% endif %}
         {% endfor %}
       </table>
+
+    </div>
+
+    <div id="crd-v1beta1-support" class="width-12-12">
+      <p><sup>1</sup> Uses <code>v1beta1</code> version of the <code>apiextensions.k8s.io</code> API which is supported only in Kubernetes 1.21 and earlier.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The supported versions table in the Download section of the website does not make it really clear which versions require `v1beta1` CRD API. This PR adds a footnote about this and links it from the corresponding versions. This should make the users checking it more aware of this.

![Screenshot 2022-04-15 at 17 56 34](https://user-images.githubusercontent.com/5658439/163592930-2e14b2f8-50e3-480c-9993-5813f2dee396.png)