### PR TITLE
Improve the margin of the Atruvia logo

### DIFF
--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -17,7 +17,7 @@
     <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/marlow-logo.svg"></div>
 
     <div class="width-4-12 width-12-12-m"></div>
-    <div class="width-4-12 width-12-12-m logo-img"><img src="{{site.baseurl}}/assets/images/atruvia_logo_online_rgb.png"></div>
+    <div class="width-4-12 width-12-12-m margin-tb-xl logo-img"><img src="{{site.baseurl}}/assets/images/atruvia_logo_online_rgb.png"></div>
     <div class="width-4-12 width-12-12-m"></div>
     
   </div>


### PR DESCRIPTION
This Pr improves the margin / spacing around the Atruvia logo to make it more similar to the other logos. The picture below shows the difference (left side is this PR, right side is the current website).

![Screenshot 2022-04-15 at 18 11 23](https://user-images.githubusercontent.com/5658439/163594612-30b572fe-4865-40e1-a02e-ddb8043ff759.png)
