### PR TITLE
Add footnote about PDB v1beta1 requirement and Kubernetes 1.25 support

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -16,6 +16,7 @@ operator:
     oAuthVersion: 0.10.0
     kafkaVersions: 3.0.0, 3.1.0
     kubernetesVersions: 1.16+
+    usesPdbV1beta1: true
     overview_book: true
     quickstart_book: true
     configuring_book: true
@@ -27,6 +28,7 @@ operator:
     oAuthVersion: 0.9.0
     kafkaVersions: 2.8.0, 2.8.1, 3.0.0
     kubernetesVersions: 1.16+
+    usesPdbV1beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -38,6 +40,7 @@ operator:
     oAuthVersion: 0.9.0
     kafkaVersions: 2.8.0, 2.8.1, 3.0.0
     kubernetesVersions: 1.16+
+    usesPdbV1beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -49,6 +52,7 @@ operator:
     oAuthVersion: 0.9.0
     kafkaVersions: 2.8.0, 2.8.1, 3.0.0
     kubernetesVersions: 1.16+
+    usesPdbV1beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -60,6 +64,7 @@ operator:
     oAuthVersion: 0.9.0
     kafkaVersions: 2.8.0, 2.8.1, 3.0.0
     kubernetesVersions: 1.16+
+    usesPdbV1beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -71,6 +76,7 @@ operator:
     oAuthVersion: 0.8.1
     kafkaVersions: 2.7.0, 2.7.1, 2.8.0
     kubernetesVersions: 1.16+
+    usesPdbV1beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -82,6 +88,7 @@ operator:
     oAuthVersion: 0.8.1
     kafkaVersions: 2.7.0, 2.7.1, 2.8.0
     kubernetesVersions: 1.16+
+    usesPdbV1beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true
@@ -93,6 +100,7 @@ operator:
     oAuthVersion: 0.7.2
     kafkaVersions: 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.8.0
     kubernetesVersions: 1.16+
+    usesPdbV1beta1: true
     overview_book: true
     quickstart_book: true
     using_book: true

--- a/_includes/downloads/supported-versions-band.html
+++ b/_includes/downloads/supported-versions-band.html
@@ -41,7 +41,7 @@
           <td class="version">{% if oRelease.bridgeVersion %}<a href="https://github.com/strimzi/strimzi-kafka-bridge/releases/tag/{{oRelease.bridgeVersion}}">{{oRelease.bridgeVersion}}</a>{% endif %}</td>
           <td class="version">{% if oRelease.oAuthVersion %}<a href="https://github.com/strimzi/strimzi-kafka-oauth/releases/tag/{{oRelease.oAuthVersion}}">{{oRelease.oAuthVersion}}</a>{% else %}n/a{% endif %}</td>
           <td class="version">{% if oRelease.kafkaVersions %}{{oRelease.kafkaVersions}}{% endif %}</td>
-          <td class="version">{% if oRelease.kubernetesVersions %}{{oRelease.kubernetesVersions}}{% endif %}{% if oRelease.usesCrdV1Beta1 %} <sup><a href="#crd-v1beta1-support">1</a></sup>{% endif %}</td>
+          <td class="version">{% if oRelease.kubernetesVersions %}{{oRelease.kubernetesVersions}}{% endif %}{% if oRelease.usesCrdV1Beta1 %} <sup><a href="#support-footnotes">1</a></sup>{% endif %}{% if oRelease.usesPdbV1beta1 %} <sup><a href="#support-footnotes">2</a></sup>{% endif %}</td>
         </tr>
           {% endif %}
         {% endfor %}
@@ -49,8 +49,9 @@
 
     </div>
 
-    <div id="crd-v1beta1-support" class="width-12-12">
+    <div id="support-footnotes" class="width-12-12">
       <p><sup>1</sup> Uses <code>v1beta1</code> version of the <code>apiextensions.k8s.io</code> API which is not supported on Kubernetes 1.22 and newer.</p>
+      <p><sup>2</sup> Uses <code>v1beta1</code> version of the <code>PodDisruptionBudget</code> API which is not supported on Kubernetes 1.25 and newer.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
In the supported versions on the download page, we already list through footnote which Strimzi use the CRDs v1beta1 because it limits the Kubernetes support. This PR adds also the footnote about Kubernetes 1.25 and PodDisruptionBudgets `v1beta1`.