### PR TITLE
Add talk from DoK Day @ KubeCon about social media analytics to the presentations

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -1,11 +1,16 @@
 strimzi_presentations:
+ - name: Build your own social media analytics with Apache Kafka
+   info: DoK Day EU 2022 @ KubeCon
+   video_url: https://youtu.be/Rt6yAqeJnLY
+   slides_url: https://docs.google.com/presentation/d/1TVVhEHwGqSlRULrLTJBKJt3BwyBsbdXbV04JpkF1ugo/edit?usp=sharing
+   demo_url: https://github.com/scholzj/DoK-Day-KubeCon-EU-2022
  - name: Road to KRaft - ZooKeeper-less Kafka in Strimzi 0.29.0
    info: YouTube video
    video_url: https://youtu.be/mT7dbLNCGtQ
  - name: StrimziPodSets - What it is and why should you care?
    info: YouTube video
    video_url: https://youtu.be/iSwrn1Gumx4
- - name: Build your own social media analytics with Apache
+ - name: Build your own social media analytics with Apache Kafka
    info: DevConf.CZ 2022
    video_url: https://youtu.be/bTxdZOWLyvI
    slides_url: https://docs.google.com/presentation/d/1vW_oTDelloUPyTkbDLiNluZXIi5t0wfFWSIDnKapESc/edit?usp=sharing


### PR DESCRIPTION
This PR adds the links to my talk about social media analytics from Data on Kubernetes Day @ KubeCon to the list of presentations.