### PR TITLE
Remove the Survey announcement band from the website

### DIFF
--- a/_includes/homepage/homepage-announcement-band.html
+++ b/_includes/homepage/homepage-announcement-band.html
@@ -1,7 +1,7 @@
 <div class="component-slim announcement_orange">
   <div class="grid-wrapper">
     <div class="width-12-12">
-        <p>Please take the <a href="https://www.surveymonkey.com/r/Strimzi-2022"> Strimzi 2022 survey</a> to let us know how you are using Strimzi. </p>
+      <p>Placeholder for an announcement</p>
     </div>
   </div>
 </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -2,7 +2,9 @@
 layout: base
 ---
 
-{% include homepage/homepage-announcement-band.html %}
+{% comment %}
+    {% include homepage/homepage-announcement-band.html %}
+{% endcomment %}
 {% include homepage/homepage-hero-band.html %}
 {% include homepage/homepage-download-announcement-band.html %}
 {% include homepage/homepage-zoom-band.html %}


### PR DESCRIPTION
Since we are going to close the Strimzi Survey soon, we should again remove the announcement band about it which was added in #304.