### PR TITLE
Add What's new in Strimzi 0.31.0 video to the blog

### DIFF
--- a/_posts/2022-09-08-what-is-new-in-strimzi-0.31.0.md
+++ b/_posts/2022-09-08-what-is-new-in-strimzi-0.31.0.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  "Video: What's new in Strimzi 0.31.0"
+date: 2022-09-08
+author: jakub_scholz
+---
+
+Strimzi 0.31.0 has been released with multiple new features and improvements.
+As with previous releases, we created a video which introduces the main changes.
+You can watch the video here or in our YouTube channel.
+
+<!--more-->
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/01dy70VlAgM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
This Pr adds the _What's new in Strimzi 0.31.0_ video to the blog post as we did with our previous releases. This should get it into the RSS readers etc.