### PR TITLE
Using YouTube handle link instead of the not readable one

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ url: "https://strimzi.io" # the base hostname & protocol for your site, e.g. htt
 twitter_username: strimziio
 github_username:  strimzi
 github_url: "https://github.com/strimzi"
+youtube_handle: strimzi
 
 # _redirects file for Netlify should be included
 include: ["_redirects"]

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -30,7 +30,7 @@
         <a href="https://twitter.com/{{site.twitter_username}}" target="_blank"><i class="fab fa-twitter"></i></a>
       </span>
       <span>
-        <a href="https://www.youtube.com/channel/UCDwPPDhB2_9lzSfYW8AGwnQ" target="_blank"><i class="fab fa-youtube"></i></a>
+        <a href="https://youtube.com/@{{site.youtube_handle}}" target="_blank"><i class="fab fa-youtube"></i></a>
       </span>
     </div>
   </div>

--- a/_includes/project-footer.html
+++ b/_includes/project-footer.html
@@ -13,7 +13,7 @@
       <p>
         <a href="{{ site.github_url }}"><i class="fab fa-github-alt"></i> Strimzi</a><br/>
         <a href="https://twitter.com/{{ site.twitter_username }}"><i class="fab fa-twitter"></i> strimziio</a><br/>
-        <a href="https://www.youtube.com/channel/UCDwPPDhB2_9lzSfYW8AGwnQ"><i class="fab fa-youtube"></i> Strimzi</a>
+        <a href="https://youtube.com/@{{site.youtube_handle}}"><i class="fab fa-youtube"></i> Strimzi</a>
       </p>
     </div>
     <div class="width-1-12"></div>


### PR DESCRIPTION
This trivial PR just replaces the unreadable link to the YouTube channel with the usage of the handle.