### PR TITLE
website(docs): Fixes links on documentation page

### DIFF
--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -11,7 +11,7 @@
         <a href="{{site.baseurl}}/docs/operators/latest/quickstart.html">Quick Start</a> <a href="/docs/operators/latest/full/quickstart.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> <br/>
         <a href="{{site.baseurl}}/docs/operators/latest/deploying.html">Deploying and Upgrading</a> <a href="/docs/operators/latest/full/deploying.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> <br/>
         <a href="{{site.baseurl}}/docs/operators/latest/configuring.html">Configuring</a> <a href="/docs/operators/latest/full/configuring.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> <br/>
-        <a href="{{site.github_url}}/strimzi/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples">Example custom resources</a>
+        <a href="{{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples">Example custom resources</a>
       </p>
       <p>
         <strong class="text-caps">Strimzi Kafka Bridge {{site.data.releases.bridge[0].version}}</strong>
@@ -23,7 +23,7 @@
       <p>
         <strong class="text-caps">In Development documentation</strong>
         <br/>
-        In development documentation corresponds to the Strimzi version that is being developed in the <a href="{{site.github_url}}/strimzi/strimzi-kafka-operator/tree/main/documentation">main branch of our GitHub repositories</a>.
+        In development documentation corresponds to the Strimzi version that is being developed in the <a href="{{site.github_url}}/strimzi-kafka-operator/tree/main/documentation">main branch of our GitHub repositories</a>.
       </p>
       <p>
         <strong class="text-caps">Strimzi Kafka operators</strong>
@@ -32,7 +32,7 @@
         <a href="{{site.baseurl}}/docs/operators/in-development/quickstart.html">Quick Start</a>  <a href="/docs/operators/in-development/full/quickstart.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
         <a href="{{site.baseurl}}/docs/operators/in-development/deploying.html">Deploying and Upgrading</a>  <a href="/docs/operators/in-development/full/deploying.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
         <a href="{{site.baseurl}}/docs/operators/in-development/configuring.html">Configuring Strimzi</a>  <a href="/docs/operators/in-development/full/configuring.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a> |
-        <a href="{{site.github_url}}/strimzi/strimzi-kafka-operator/tree/main/examples">Example custom resources</a>
+        <a href="{{site.github_url}}/strimzi-kafka-operator/tree/main/examples">Example custom resources</a>
       </p>
       <p>
       <strong class="text-caps">Strimzi Kafka Bridge</strong>


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Links using `{{site.github_url}}` had an additional `strimzi` in the path.
Removed


* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
