### PR TITLE
Add the local storage video to the website as blog post and to the videos and presentations section

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -1,4 +1,7 @@
 strimzi_presentations:
+ - name: "Make your Kafka cluster production-ready: Local Storage"
+   info: Video series episode
+   video_url: https://youtu.be/RMJ6Ap88fpk
  - name: Leader Election - Running Cluster Operator with multiple replicas
    info: YouTube video
    video_url: https://youtu.be/IuHyO-Bns88

--- a/_posts/2022-12-23-make-your-kafka-cluster-production-ready-local-storage.md
+++ b/_posts/2022-12-23-make-your-kafka-cluster-production-ready-local-storage.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  "Video: Make your Kafka cluster production-ready - Local Storage"
+date: 2022-12-23
+author: jakub_scholz
+---
+
+Make your Kafka cluster production-ready is our video series which will take you through the main things you should take care of when setting up a production cluster.
+In this episode, we will look at the advantages and disadvantages of using local storage compared to network storage.
+You can watch the video here or in our YouTube channel.
+
+<!--more-->
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/RMJ6Ap88fpk" title="Make your Kafka cluster production-ready: Local Storage" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
For better visibility, this PR adds the _Make your Kafka cluster production-ready: Local Storage_ YouTube video also as a blog post and to the presentations and videos section. This should also get it to the RSS readers and search engines.