### PR TITLE
Remove Helm 2 chart from the Downloads page

### DIFF
--- a/_includes/downloads/downloads-release-band.html
+++ b/_includes/downloads/downloads-release-band.html
@@ -30,13 +30,6 @@
             </td>
           </tr>
           <tr>
-            <td class="description">strimzi-kafka-operator-helm-2-chart-{{oRelease}}</td>
-            <td class="licence">AL 2.0</td>
-            <td class="links">
-              <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{oRelease}}/strimzi-kafka-operator-helm-2-chart-{{oRelease}}.tgz">tgz</a>
-            </td>
-          </tr>
-          <tr>
             <td class="description">strimzi-kafka-operator-helm-3-chart-{{oRelease}}</td>
             <td class="licence">AL 2.0</td>
             <td class="links">
@@ -55,6 +48,13 @@
             <td class="licence">AL 2.0</td>
             <td class="links">
               <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{oRelease}}/strimzi-user-operator-{{oRelease}}.yaml">yaml</a>
+            </td>
+          </tr>
+          <tr>
+            <td class="description">strimzi-crds-{{oRelease}}</td>
+            <td class="licence">AL 2.0</td>
+            <td class="links">
+              <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/download/{{oRelease}}/strimzi-crds-{{oRelease}}.yaml">yaml</a>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
For whatever reason, we have on the Downloads page on the website a download link for the Helm 2 chart which we do not support for a long time. This PR removes it and instead adds a link to the CRDs YAML file.