### PR TITLE
Fix typo in logging blog post

### DIFF
--- a/_posts/2020-11-10-dynamically-changeable-logging.md
+++ b/_posts/2020-11-10-dynamically-changeable-logging.md
@@ -73,7 +73,7 @@ Example of `inline` logging.
 logging:
   type: inline
   loggers:
-    kafka.root.logger.level = INFO
+    kafka.root.logger.level: INFO
 ...
 ```
 


### PR DESCRIPTION
This PR fixes a typo in the logging blog post which is using `=` instead of `:`.

This should close #358