### PR TITLE
Highlight the `Documentation` menu when in docs

### DIFF
--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -15,7 +15,7 @@
         <a href="{{site.baseurl}}/downloads/" class="{% if page.url contains '/downloads/' %}active{% endif %}">Downloads</a>
       </span>
       <span>
-        <a href="{{site.baseurl}}/documentation/" class="{% if page.url contains '/documentation/' %}active{% endif %}">Documentation</a>
+        <a href="{{site.baseurl}}/documentation/" class="{% if page.url contains '/documentation/' or page.url contains '/docs/' %}active{% endif %}">Documentation</a>
       </span>
       <span>
         <a href="{{site.baseurl}}/join-us/" class="{% if page.url contains '/join-us/' %}active{% endif %}">Join Us</a>


### PR DESCRIPTION
We should add the orange highlight to the `Documentation` menu when the user is in the docs:

![Screenshot 2023-04-24 at 20 32 16](https://user-images.githubusercontent.com/5658439/234085344-ffc6fc57-a6a6-437b-a169-59510a45445b.png)
