### PR TITLE
docs(tables): adds properties to control table content

### DIFF
--- a/_sass/core/global.scss
+++ b/_sass/core/global.scss
@@ -203,6 +203,8 @@ img { max-width: 100%; }
 
 table {
   border-spacing: 1px;
+  display: block;
+  overflow-x: auto !important;
 
   thead th, tbody td {
     padding: .5rem 1rem;


### PR DESCRIPTION
### Type of change

**Documentation content update**
One or two of the tables in the docs overflow their container.
This PR adds adds CSS properties that adds a scroll bar to a table if the content overflows.
As far as I can see, this is only applicable to a couple of tables. 
See the following in the Configuring guide:

* Table 1. MirrorMaker 2 connector configuration properties
* KafkaClusterSpec schema properties

Fix type:
* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
