### PR TITLE
docs(tables): local properties to control large tables in the docs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,6 +31,14 @@
 {% include site-scripts.html %}
 </html>
 
+<style>
+  /* adds a horizontal scroll bar to any doc tables that expand beyond the container */
+  table {
+    display: block;
+    overflow-x: auto !important;
+  }
+</style>
+
 <script>
 const footer = document.querySelector('#footer');
 const toc = document.querySelector('.toc-left');


### PR DESCRIPTION
### Type of change

**Documentation content update**
One or two of the tables in the docs overflow their container.
This PR adds adds CSS properties that adds a scroll bar to a table if the content overflows.
Previously, this was set in the global CSS, which impacted the downloads page [#364]

As far as I can see, this is only applicable to a couple of tables.
See the following in the Configuring guide:

Table 1. MirrorMaker 2 connector configuration properties
KafkaClusterSpec schema properties

* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
