### PR TITLE
docs(resize): adds resize to table of contents for docs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,32 +1,32 @@
 <!DOCTYPE html>
 <html>
 
-{% include site-header.html %} 
- <div class="doc-nav">
+{% include site-header.html %}
+<div class="doc-nav">
   <nav class="site-content">
-    {% include header-navigation.html %} 
-  </nav> 
- </div> 
+    {% include header-navigation.html %}
+  </nav>
+</div>
 
- <body class="{% if page.url == '/' %}homepage{% else %}{{page.layout}}{% endif %}">
+<body class="{% if page.url == '/' %}homepage{% else %}{{page.layout}}{% endif %}">
   <div class="doc-main">
-      <nav class="toc-left">
-          {% include toc.html html=content %}
-      </nav>
-      
-      <div class="doc-content"> 
-        <h1>
-          {{ page.title | replace: '!LATEST_OPERATOR_VERSION!', site.data.releases.operator[0].version | replace:
-          '!LATEST_BRIDGE_VERSION!', site.data.releases.bridge[0].version }}
-        </h1>
-        {{ content }}
-      </div> 
+    <nav class="toc-left">
+      {% include toc.html html=content %}
+    </nav>
+
+    <div class="doc-content">
+      <h1>
+        {{ page.title | replace: '!LATEST_OPERATOR_VERSION!', site.data.releases.operator[0].version | replace:
+        '!LATEST_BRIDGE_VERSION!', site.data.releases.bridge[0].version }}
+      </h1>
+      {{ content }}
+    </div>
   </div>
 </body>
 
-  <nav class="site-content footer" id="footer">
+<nav class="site-content footer" id="footer">
   {% include project-footer.html %}
- </nav>
+</nav>
 
 {% include site-scripts.html %}
 </html>
@@ -40,16 +40,52 @@
 </style>
 
 <script>
-const footer = document.querySelector('#footer');
-const toc = document.querySelector('.toc-left');
+  const footer = document.querySelector('#footer');
+  const toc = document.querySelector('.toc-left');
+  const content = document.querySelector('.doc-content');
 
-window.addEventListener('scroll', () => {
-  const rect = footer.getBoundingClientRect();
-  if (rect.top < window.innerHeight && rect.bottom > 0) {
-    toc.classList.add('footer-visible');
-  } else {
-    toc.classList.remove('footer-visible');
+  let isResizing = false;
+
+  function setWidth() {
+    if (isResizing) return;
+
+    isResizing = true;
+
+    setTimeout(() => {
+      const tocWidth = toc.offsetWidth;
+      const adjustedWidth = `calc(100% - ${tocWidth}px)`;
+      content.style.width = adjustedWidth;
+      isResizing = false;
+    }, 500);
   }
-});
+
+  function throttleTocResize(func, delay) {
+    let isResizing = false;
+
+    return function () {
+      if (isResizing) return;
+
+      isResizing = true;
+
+      setTimeout(() => {
+        func();
+        isResizing = false;
+      }, delay);
+    };
+  }
+
+  setWidth();
+
+  window.addEventListener('resize', throttleTocResize(setWidth, 800));
+  toc.addEventListener('mousemove', throttleTocResize(setWidth, 800));
+
+  window.addEventListener('scroll', () => {
+    const rect = footer.getBoundingClientRect();
+    if (rect.top < window.innerHeight && rect.bottom > 0) {
+      toc.classList.add('footer-visible');
+    } else {
+      toc.classList.remove('footer-visible');
+    }
+  });
 
 </script>

--- a/_sass/includes/toc.scss
+++ b/_sass/includes/toc.scss
@@ -45,10 +45,12 @@
 @media only screen and (min-width: 1024px) and (max-width: 1450px) {
 
   .doc-content {
-    width: 70% !important;
     float: right;
     padding-right: 1rem;
+    padding-left: 3rem;
     overflow-x: hidden;
+    box-sizing: border-box;
+    width: 75%
   }
 
   .doc-content .toc {
@@ -83,10 +85,12 @@
 @media only screen and (min-width: 1450px) { 
 
   .doc-content {
-    width: 70% !important;
     float: right;
     padding-right: 1rem;
+    padding-left: 3rem;
     overflow-x: hidden;
+    box-sizing: border-box;
+    width: 75%
   }
 
   .doc-content .toc {
@@ -252,12 +256,16 @@
 
 .toc-left {
   position: fixed;
-  left: 0;
+  float: left;
+  resize: horizontal;
   width: 25%;
+  min-width: 0%;
+  max-width: 40%;
   overflow: auto;
   padding-left: 10px;
   z-index: 0;
-  border-right: #182C46;
+  box-sizing: border-box;
+  border-right: 1px solid #dadfe6; 
 }
 
 .toc-left ul {


### PR DESCRIPTION
**Docs pages**

Adds a control to allow resize of the Table of Contents by adding a resize handle to the scrollbar.
The width can be adjusted up to 40% or 0% to remove the ToC from display

* [ ] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
