### PR TITLE
Fix incorrect URL in the Helm Chart index

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -13,7 +13,7 @@ entries:
     - https://github.com/strimzi/drain-cleaner
     type: application
     urls:
-    - https://github.com/strimzi/drain-cleaner/releases/tag/0.5.0/strimzi-drain-cleaner-helm-3-chart-0.5.0.tgz
+    - https://github.com/strimzi/drain-cleaner/releases/download/0.5.0/strimzi-drain-cleaner-helm-3-chart-0.5.0.tgz
     version: 0.5.0
   - apiVersion: v2
     appVersion: 0.4.2


### PR DESCRIPTION
This Pr fixes the incorrect URL in the Helm Chart index file.

This should resolve https://github.com/strimzi/drain-cleaner/issues/92