### PR TITLE
docs(pages): docs presentation changes

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -82,9 +82,9 @@
     {% capture listModifier %}{% if orderedList %}ol{% else %}ul{% endif %}{% endcapture %}
 
     {% for node in nodes %}
-        {% if node == "" %}
-            {% continue %}
-        {% endif %}
+    {% if node == "" or node contains 'class="discrete"' %}
+        {% continue %}
+    {% endif %}
 
         {% assign currLevel = node | replace: '"', '' | slice: 0, 1 | times: 1 %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
 <body class="{% if page.url == '/' %}homepage{% else %}{{page.layout}}{% endif %}">
   <div class="doc-main">
     <nav class="toc-left">
-      {% include toc.html html=content %}
+      {% include toc.html html=content sanitize=true item_class="toc_heading_%level%" h_min=2 h_max=4 %}
     </nav>
 
     <div class="doc-content">
@@ -19,6 +19,7 @@
         {{ page.title | replace: '!LATEST_OPERATOR_VERSION!', site.data.releases.operator[0].version | replace:
         '!LATEST_BRIDGE_VERSION!', site.data.releases.bridge[0].version }}
       </h1>
+      <p style="text-align: right; font-size: 1rem;"><i class="fa fa-edit"></i> <a href="https://github.com/strimzi/strimzi-kafka-operator/tree/main/documentation" target="_blank">Edit this page</a></p>
       {{ content }}
     </div>
   </div>

--- a/_sass/core/global.scss
+++ b/_sass/core/global.scss
@@ -256,6 +256,19 @@ table {
   }
 }
 
+.imageblock {
+  display: flex;
+  flex-direction: column;
+}
+
+.imageblock .content {
+  order: 2;
+}
+
+.imageblock .title {
+  order: 1;
+}
+
 .paginator-btns a {
   margin: 1rem 0;
   line-height: 1.5;

--- a/_sass/includes/toc.scss
+++ b/_sass/includes/toc.scss
@@ -27,17 +27,20 @@
   }
 
   h2 {
-    font-size: 1.5rem;
+    font-size: 1.8rem;
   }
   
   h3 {
-    font-size: 1.25rem;
+    font-size: 1.6rem;
   }
 
   h4 {
-    font-size: 1rem;
+    font-size: 1.4rem;
   }
 
+  h5 {
+    font-size: 1.2rem;
+  }
 }
 
 /* For tablet devices */
@@ -67,15 +70,19 @@
   }
 
   h2 {
-    font-size: 2.4rem;
+    font-size: 2rem;
   }
   
   h3 {
-    font-size: 1.6rem;
+    font-size: 1.8rem;
   }
 
   h4 {
-    font-size: 1.25rem;
+    font-size: 1.6rem;
+  }
+
+  h5 {
+    font-size: 1.4rem;
   }
 
 }
@@ -98,7 +105,7 @@
   }
   
   h2 {
-    font-size: 3rem;
+    font-size: 2.2rem;
   }
   
   h3 {
@@ -106,7 +113,11 @@
   }
 
   h4 {
-    font-size: 1.75rem;
+    font-size: 1.8rem;
+  }
+
+  h5 {
+    font-size: 1.6rem;
   }
 
 }
@@ -284,6 +295,15 @@
   color: #182C46 !important;
   text-decoration: none;
   transition: all 0.2s;
+  }
+
+ul.sectlevel1 li a.link {
+  font-weight: bold !important;
+  }
+
+/* makes top section heading bold in ToC */
+.toc_heading_2 > a:first-child {
+  font-weight: bold;
   }
 
   li > ul {


### PR DESCRIPTION
**Docs web pages**

A few small changes to the presentation of the docs:

   - Puts figure titles above diagrams
   - Makes top-level ToC headings bold
   - Uses 3 heading levels in ToC (removes unnumbered sections from)
   - Removes discrete headings from ToC
   - Adds _edit this page_ link to source docs files


* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
