### PR TITLE
Where is Strimzi 1.0.0?

### DIFF
--- a/_posts/2023-12-06-where-is-Strimzi-1.0.0.md
+++ b/_posts/2023-12-06-where-is-Strimzi-1.0.0.md
@@ -8,7 +8,7 @@ author: jakub_scholz
 If you have been using Strimzi for some time, you might be wondering about its versioning.
 Why does Strimzi still have only some _zero-dot-something_ versions?
 Where is Strimzi 1.0.0?
-So in this blog post, we will look at the history behind it and our latest plans for the 1.0.0 release.
+In this blog post, we will look at the history behind this and outline our latest plans for the 1.0.0 release.
 
 _This blog post is a personal opinion of the author and might not represent the view of the whole Strimzi community._
 
@@ -26,7 +26,7 @@ That came only with the 0.2.0 release.
 
 Neither 0.1.0 nor 0.2.0 were of course production-ready.
 They were just the first steps on a long road.
-But with every release, we added more and more features, fixed bugs, and improved things ... and suddenly, we had our first production users and the first companies started to offer commercial products based on Strimzi.
+But with every release, we added more and more features, fixed bugs, and made improvements ... and suddenly, we had our first production users and the first companies started to offer commercial products based on Strimzi.
 With more and more users, we started thinking about releasing Strimzi 1.0.0.
 
 But there was a thing on the horizon ... the _ZooKeeper-less Apache Kafka_ (also called _KRaft mode_).
@@ -50,9 +50,9 @@ If I had the chance to go back and change it, I would surely propose to do the 1
 ### Does it mean Strimzi is not production-ready?
 
 Absolutely not!
-We realize the 0.x version might seem scary and might put people off.
+We realize the 0.x version might seem concerning and might deter some people.
 However, the version number itself does not say much about the project maturity or about how good the project is.
-All of us in Strimzi believe that Strimzi production-ready.
+Strimzi is production-ready!
 And you can check the logos of some of our production users on our website as proof.
 
 And despite being only at 0.x version, we do our best to maintain backward compatibility on the API level as well in how the Strimzi operators work.

--- a/_posts/2023-12-06-where-is-Strimzi-1.0.0.md
+++ b/_posts/2023-12-06-where-is-Strimzi-1.0.0.md
@@ -42,7 +42,7 @@ So we decided to not release Strimzi 1.0.0 and wait for the ZooKeeper removal to
 It turned out that the ZooKeeper removal from Apache Kafka took longer than we initially expected.
 In fact - it is still in progress - although it seems like it is slowly coming to an end and hopefully, next year will see the release of Apache Kafka 4.0 without ZooKeeper support.
 At the time of writing this blog post, Strimzi has 0.38.0 as its last release.
-That means 38 minor releases without releasing 1.0.0.
+That means 38 versions without releasing 1.0.0.
 
 So, looking back, the decision we took a long time ago was probably a mistake.
 If I had the chance to go back and change it, I would surely propose to do the 1.0.0 release already back then and now we would be talking only about _when to do the 2.0.0 release_.
@@ -53,7 +53,7 @@ Absolutely not!
 We realize the 0.x version might seem concerning and might deter some people.
 However, the version number itself does not say much about the project maturity or about how good the project is.
 Strimzi is production-ready!
-And you can check the logos of some of our production users on our website as proof.
+And you can check some of our production users on our [website](https://strimzi.io/) or in our [`ADOPTERS.md` file](https://github.com/strimzi/strimzi-kafka-operator/blob/main/ADOPTERS.md) as proof.
 
 And despite being only at 0.x version, we do our best to maintain backward compatibility on the API level as well in how the Strimzi operators work.
 So you should not have anything to worry about!

--- a/_posts/2023-12-06-where-is-Strimzi-1.0.0.md
+++ b/_posts/2023-12-06-where-is-Strimzi-1.0.0.md
@@ -26,21 +26,23 @@ That came only with the 0.2.0 release.
 
 Neither 0.1.0 nor 0.2.0 were of course production-ready.
 They were just the first steps on a long road.
-But with every release, we added more and more features, fixed bugs, and made improvements ... and suddenly, we had our first production users and the first companies started to offer commercial products based on Strimzi.
+With each subsequent release, we incorporated additional features, addressed bugs, and implemented improvements.
+Before we knew it, we welcomed our first production users, and companies began offering commercial products built on Strimzi.
 With more and more users, we started thinking about releasing Strimzi 1.0.0.
 
 But there was a thing on the horizon ... the _ZooKeeper-less Apache Kafka_ (also called _KRaft mode_).
-The [KIP-500](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum) was published in August 2019.
-But already before we knew that there were plans to change the dependence on Apache ZooKeeper.
+The [KIP-500](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum) proposal to replace ZooKeeper was published in August 2019.
+Even before this KIP was published, we were aware of plans to alter the dependency on Apache ZooKeeper.
 Everyone knew that removing ZooKeeper from Kafka would not be a simple task.
 We knew that it would take a long time and mean many different changes.
 Changes to Apache Kafka, its Admin API and the way it is managed and configured.
 But also changes to Strimzi.
 For example, without ZooKeeper, the layout of our `Kafka` custom resource with its dedicated `.spec.kafka` and `.spec.zookeeper` sections does not make sense anymore.
-So we decided to not release Strimzi 1.0.0 and wait for the ZooKeeper removal to be finished.
+So we decided to not release Strimzi 1.0.0 and wait for the ZooKeeper removal process to be completed.
 
 It turned out that the ZooKeeper removal from Apache Kafka took longer than we initially expected.
-In fact - it is still in progress - although it seems like it is slowly coming to an end and hopefully, next year will see the release of Apache Kafka 4.0 without ZooKeeper support.
+In fact, the process is still underway, though it seems like it is slowly coming to an end.
+Hopefully, next year will see the release of Apache Kafka 4.0 without ZooKeeper support.
 At the time of writing this blog post, Strimzi has 0.38.0 as its last release.
 That means 38 versions without releasing 1.0.0.
 
@@ -49,7 +51,8 @@ If I had the chance to go back and change it, I would surely propose to do the 1
 
 ### Does it mean Strimzi is not production-ready?
 
-Absolutely not!
+Does the current versioning mean Strimzi is not production-ready?
+No, absolutely not!
 We realize the 0.x version might seem concerning and might deter some people.
 However, the version number itself does not say much about the project maturity or about how good the project is.
 Strimzi is production-ready!
@@ -82,5 +85,5 @@ But then we will be finally there - at version 1.0.0.
 To be clear, this blog post is not intended in any way to blame the Apache Kafka community for how long it takes to remove ZooKeeper from Kafka.
 Any decisions about the Strimzi 1.0.0 release and any expectations about how long will ZooKeeper removal take were only our own.
 Hopefully, it will instead make it clearer why we still do only some 0.x release and when to expect the Strimzi 1.0.0 release.
-And it should also make you less afraid of using it despite the version starting still with zero.
-And help to learn from our mistakes!
+And it should also make you less afraid of using it despite the version still starting with a zero.
+And help you learn from our mistakes!

--- a/_posts/2023-12-06-where-is-Strimzi-1.0.0.md
+++ b/_posts/2023-12-06-where-is-Strimzi-1.0.0.md
@@ -1,0 +1,86 @@
+---
+layout: post
+title:  "Where is Strimzi 1.0.0?"
+date: 2023-12-06
+author: jakub_scholz
+---
+
+If you have been using Strimzi for some time, you might be wondering about its versioning.
+Why does Strimzi still have only some _zero-dot-something_ versions?
+Where is Strimzi 1.0.0?
+So in this blog post, we will look at the history behind it and our latest plans for the 1.0.0 release.
+
+_This blog post is a personal opinion of the author and might not represent the view of the whole Strimzi community._
+
+<!--more-->
+
+### The history
+
+Strimzi is almost 6 years old.
+For a software project, 6 years is not a _short time_.
+When we initially started it, we started it _boldly_.
+Our first version was not called 0.0.1 but 0.1.0.
+The 0.1.0 release was not yet based on the operator pattern.
+That came only with the 0.2.0 release.
+0.1.0 was just a bunch of YAML files to make it easier to deploy Apache Kafka.
+
+Neither 0.1.0 nor 0.2.0 were of course production-ready.
+They were just the first steps on a long road.
+But with every release, we added more and more features, fixed bugs, and improved things ... and suddenly, we had our first production users and the first companies started to offer commercial products based on Strimzi.
+With more and more users, we started thinking about releasing Strimzi 1.0.0.
+
+But there was a thing on the horizon ... the _ZooKeeper-less Apache Kafka_ (also called _KRaft mode_).
+The [KIP-500](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum) was published in August 2019.
+But already before we knew that there were plans to change the dependence on Apache ZooKeeper.
+Everyone knew that removing ZooKeeper from Kafka would not be a simple task.
+We knew that it would take a long time and mean many different changes.
+Changes to Apache Kafka, its Admin API and the way it is managed and configured.
+But also changes to Strimzi.
+For example, without ZooKeeper, the layout of our `Kafka` custom resource with its dedicated `.spec.kafka` and `.spec.zookeeper` sections does not make sense anymore.
+So we decided to not release Strimzi 1.0.0 and wait for the ZooKeeper removal to be finished.
+
+It turned out that the ZooKeeper removal from Apache Kafka took longer than we initially expected.
+In fact - it is still in progress - although it seems like it is slowly coming to an end and hopefully, next year will see the release of Apache Kafka 4.0 without ZooKeeper support.
+At the time of writing this blog post, Strimzi has 0.38.0 as its last release.
+That means 38 minor releases without releasing 1.0.0.
+
+So, looking back, the decision we took a long time ago was probably a mistake.
+If I had the chance to go back and change it, I would surely propose to do the 1.0.0 release already back then and now we would be talking only about _when to do the 2.0.0 release_.
+
+### Does it mean Strimzi is not production-ready?
+
+Absolutely not!
+We realize the 0.x version might seem scary and might put people off.
+However, the version number itself does not say much about the project maturity or about how good the project is.
+All of us in Strimzi believe that Strimzi production-ready.
+And you can check the logos of some of our production users on our website as proof.
+
+And despite being only at 0.x version, we do our best to maintain backward compatibility on the API level as well in how the Strimzi operators work.
+So you should not have anything to worry about!
+
+### How do we get out of it?
+
+So what is the plan for Strimzi 1.0.0?
+When we realized that the ZooKeeper removal would take much longer than originally anticipated, we had two options.
+Change our mind and release 1.0.0.
+Or stick with our decision.
+And since the KRaft implementation was progressing in the Apache Kafka community and it seemed to be closer and closer, we decided to stick to our decision.
+Maybe that was another mistake, who knows?
+Things always seem like they are almost there.
+
+But hopefully, the _next year_ will really be the **next year** when it happens.
+If everything goes according to the _latest_ plans, Apache Kafka 4.0 without ZooKeeper support will be released in 2024.
+Once it is released and supported by Strimzi, we will proceed and update the `Kafka` custom resource to reflect this change.
+The updated `Kafka` resource will be used for the Strimzi `v1` API.
+And the `v1` API will be hopefully soon followed by the Strimzi 1.0.0 release.
+This might take another few months to stabilize the APIs, catch the last bugs and so on.
+So depending on when the Kafka 4.0.0 release happens, it might not be 2024 anymore.
+But then we will be finally there - at version 1.0.0.
+
+### Learning from our mistakes
+
+To be clear, this blog post is not intended in any way to blame the Apache Kafka community for how long it takes to remove ZooKeeper from Kafka.
+Any decisions about the Strimzi 1.0.0 release and any expectations about how long will ZooKeeper removal take were only our own.
+Hopefully, it will instead make it clearer why we still do only some 0.x release and when to expect the Strimzi 1.0.0 release.
+And it should also make you less afraid of using it despite the version starting still with zero.
+And help to learn from our mistakes!

--- a/_posts/2023-12-11-where-is-Strimzi-1.0.0.md
+++ b/_posts/2023-12-11-where-is-Strimzi-1.0.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Where is Strimzi 1.0.0?"
-date: 2023-12-06
+date: 2023-12-11
 author: jakub_scholz
 ---
 


### PR DESCRIPTION
I feel like we should have some explanation why we are still using 0.x versions. So I put together this blog post that tries to explain it and also outline the next steps. Please have a look and let me know what you think ...

### Type of change

* [x] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
