### PR TITLE
Added Strimzi presentation at CNCF Napoli community group

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -1,4 +1,9 @@
 strimzi_presentations:
+ - name: Apache Kafka on Kubernetes with Strimzi
+   info: CNCF Napoli Cloud Native Community Group
+   video_url: https://www.youtube.com/watch?v=2HnbCJ7Jblw
+   slides_url: https://github.com/cncfnapoli/cncfnapoli-group/blob/master/2023-11-29/apache_kafka_on_kubernetes_with_strimzi.pdf
+   demo_url: https://github.com/ShubhamRwt/CNCF-Napoli-meetup
  - name: Make Your Kafka Cluster Production-ready
    info: DoK Day @ KubeCon NA 2023
    video_url: https://youtu.be/l0iEJEOVqsg


### PR DESCRIPTION
This PR adds recording and material links for the Strimzi presentation at the CNCF Napoli Cloud Native Community Group to the presentations section.
