### PR TITLE
docs(style): styles for large tables in the docs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,7 +51,7 @@
   /* adds a horizontal scroll bar to any doc tables that expand beyond the container */
   table {    
     overflow-x: auto !important;
-    display:block;
+    display: block;
 }
 </style>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,6 +47,14 @@
 {% include site-scripts.html %}
 </html>
 
+<style>
+  /* adds a horizontal scroll bar to any doc tables that expand beyond the container */
+  table {    
+    overflow-x: auto !important;
+    display:block;
+}
+</style>
+
 <script>
 
   const footer = document.querySelector('#footer');

--- a/_sass/includes/toc.scss
+++ b/_sass/includes/toc.scss
@@ -451,7 +451,3 @@ input:checked + .slider:before {
   height: 45px;
 }
 
-/* adds a horizontal scroll bar to any doc tables that expand beyond the container */
-  table {    
-    overflow-x: auto !important;
-}


### PR DESCRIPTION
**Documentation content update**

Moves the style settings for large tables so that they are local and affect only documentation tables
The CSS properties  add a scroll bar to a table if the content overflows.
Previously, this was being set in the global CSS, which impacted the downloads page 

* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
