### PR TITLE
Add Drain Cleaner 1.1.0 to the Helm chart index

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -2,6 +2,21 @@ apiVersion: v1
 entries:
   strimzi-drain-cleaner:
   - apiVersion: v2
+    appVersion: 1.1.0
+    created: "2024-03-02T12:25:31.17711+01:00"
+    description: Utility which helps with moving the Apache Kafka pods deployed by
+      Strimzi from Kubernetes nodes which are being drained.
+    digest: 04271f4257e873006af533c6862de87016526af2fb37991b71de82d2fd865a20
+    home: https://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
+    name: strimzi-drain-cleaner
+    sources:
+    - https://github.com/strimzi/drain-cleaner
+    type: application
+    urls:
+    - https://github.com/strimzi/drain-cleaner/releases/download/1.1.0/strimzi-drain-cleaner-helm-3-chart-1.1.0.tgz
+    version: 1.1.0
+  - apiVersion: v2
     appVersion: 1.0.1
     created: "2023-11-23T13:15:47.165642+01:00"
     description: Utility which helps with moving the Apache Kafka pods deployed by
@@ -1549,4 +1564,4 @@ entries:
     urls:
     - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
     version: 0.6.0
-generated: "2023-12-20T20:32:55.13524+01:00"
+generated: "2024-03-02T12:25:31.176621+01:00"


### PR DESCRIPTION
This PR adds the Drain Cleaner 1.1.0 to the Helm Chart index on the website.