### PR TITLE
Replace the StrimziCon CfP with call for registration

### DIFF
--- a/_includes/homepage/homepage-announcement-band.html
+++ b/_includes/homepage/homepage-announcement-band.html
@@ -1,8 +1,7 @@
 <div class="component-slim announcement_orange">
   <div class="grid-wrapper">
     <div class="width-12-12">
-      <p>Don't miss out on your chance to shine at <a href="https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/">StrimziCon</a> in May!
-        The <a href="https://sessionize.com/strimzicon-2024/">Call for Papers</a> closes on March 10th.</p>
+      <p>Join us for StrimziCon: a virtual conference about the Strimzi project on May 22nd. <a href="https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/">Register now</a>!</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
As the StrimziCOn CfP is now closed, this PR replaces the call for papers banner ont he website with the call for registration.