### PR TITLE
Fix style for bold/strong text

### DIFF
--- a/_sass/core/global.scss
+++ b/_sass/core/global.scss
@@ -117,6 +117,10 @@ p.byline {
   line-height: 1.8rem;
 }
 
+b,strong {
+  font-weight: bold;
+}
+
 a {
   line-height: 1.5rem;
   font-weight: 400;


### PR DESCRIPTION
### Type of change

- Fix

### Description

This PR fixes issue with the style of `<b>`/`<strong>` elements, as the text wasn't highlighted at all.
The reason is that the style of those two tags were overwritten by style of other "parent" elements -> `<p>`, `<ul>`, .etc.

For not inheriting the `font-weight` for `b, strong` elements, I added explicit style for them, which fixes the issue.

Before:

<img width="1938" alt="image" src="https://github.com/strimzi/strimzi.github.io/assets/53821852/98b6b12c-6947-412d-8ac9-92fc8ca9378e">

After:

<img width="1580" alt="image" src="https://github.com/strimzi/strimzi.github.io/assets/53821852/d5b2d205-5e5b-40d5-8775-b179f4790424">

