### PR TITLE
Correct style for announcement on mobile and tablet

### DIFF
--- a/_sass/strimzi.scss
+++ b/_sass/strimzi.scss
@@ -524,6 +524,16 @@ blockquote::after {
   margin: 0 -13rem;
   padding: 2rem 13rem;
 
+  @media screen and (max-width: 1170px) {
+    margin: 0 -6rem;
+    padding: 2rem 6rem;
+  }
+
+  @media screen and (max-width: 768px) {
+    margin: 0 -2rem;
+    padding: 2rem;
+  }
+
   p {
     font-size: 1.5rem;
     line-height: 1.75rem;


### PR DESCRIPTION
### Type of change

- Minor fix

### Description

This PR adds configuration of `margin` and `padding` for announcement banner on mobile and tablet.

Before:

(mobile)
<img width="429" alt="image" src="https://github.com/strimzi/strimzi.github.io/assets/53821852/bd58a830-ed62-49d5-bfbc-534db78f8f52">

(tablet)
<img width="811" alt="image" src="https://github.com/strimzi/strimzi.github.io/assets/53821852/71719bcb-c67e-4ae9-bfce-78f5a3181f9f">

After:

(mobile)
<img width="432" alt="image" src="https://github.com/strimzi/strimzi.github.io/assets/53821852/2fa9b34b-d5f4-4d71-ac43-9dfbfaafcd0a">

(tablet)
<img width="811" alt="image" src="https://github.com/strimzi/strimzi.github.io/assets/53821852/afd009e6-6294-4c5b-8031-ecea053d239c">
