### PR TITLE
Add KubeCon Europe 2024 talks

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -1,4 +1,10 @@
 strimzi_presentations:
+ - name: "Released From the Cage: Apache Kafka Without Its ZooKeeper"
+   info: DoK Day @ KubeCon Europe 2024
+   video_url: https://youtu.be/74fDjwigLms
+ - name: "Strimzi: Toward a ZooKeeper-less Future"
+   info: KubeCon Europe 2024
+   video_url: https://youtu.be/_zpjMh8p02Y
  - name: Apache Kafka on Kubernetes with Strimzi
    info: CNCF Napoli Cloud Native Community Group
    video_url: https://www.youtube.com/watch?v=2HnbCJ7Jblw


### PR DESCRIPTION
This PR adds the KubeCon Europe 2024 talks to the presentation list.