### PR TITLE
Added blog post about StrimziCon 2024 schedule

### DIFF
--- a/_posts/2024-04-08-strimzicon2024-schedule.md
+++ b/_posts/2024-04-08-strimzicon2024-schedule.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "StrimziCon 2024: schedule announced!"
+title:  "StrimziCon 2024: Schedule announced!"
 date: 2024-04-08
 author: paolo_patierno
 ---
@@ -21,11 +21,11 @@ The keynote will be followed by 3 hours of breakout sessions covering several to
 
 | Time | River room | Waterfall room |
 |:---:|:---:|:---:|
-| 14:30 - 14:50 | Keynote (Kate Stanley & Paolo Patierno @Red Hat) | Keynote (Kate Stanley & Paolo Patierno @Red Hat) |
-| 15:00 - 15:40 | Upgrade yourself to the Business Class (Jakub Scholz @Red Hat) | Exploring Strimzi’s implementation of rolling updates (Gantigmaa Selenge @Red Hat) |
-| 15:50 - 16:30 | Transition to Apache Kafka on Kubernetes with Strimzi (Steffen Wirenfeldt Karlsson @Maersk) | Modernizing Nubank's Kafka Platform For The Next 10 Years Starting at 1 Trillion Messages per Month (Julio Turolla, Roni Silva @Nubank) |
-| 16:40 - 17:20 | Enhancing Kafka Topic Management in Kubernetes with the Unidirectional Topic Operator (Federico Valeri @Red Hat) | Partial Multi-Tenancy on Kafka using Strimzi at LittleHorse (Colt McNealy @LittleHorse) |
-| 17:30 - 18:10 | How to survive managing Strimzi in an enterprise (Richard Bosch, @Axual BV) | Support Tiered Storage in Strimzi operated Kafka (Lixin Yao, Vrishali Bhor, bo gao @Apple) |
+| 14:30 - 14:50 | Keynote (Kate Stanley & Paolo Patierno @ Red Hat) | Keynote (Kate Stanley & Paolo Patierno @ Red Hat) |
+| 15:00 - 15:40 | Upgrade yourself to the Business Class (Jakub Scholz @ Red Hat) | Exploring Strimzi’s implementation of rolling updates (Gantigmaa Selenge @ Red Hat) |
+| 15:50 - 16:30 | Transition to Apache Kafka on Kubernetes with Strimzi (Steffen Wirenfeldt Karlsson @ Maersk) | Modernizing Nubank's Kafka Platform For The Next 10 Years Starting at 1 Trillion Messages per Month (Julio Turolla, Roni Silva @ Nubank) |
+| 16:40 - 17:20 | Enhancing Kafka Topic Management in Kubernetes with the Unidirectional Topic Operator (Federico Valeri @ Red Hat) | Partial Multi-Tenancy on Kafka using Strimzi at LittleHorse (Colt McNealy @ LittleHorse) |
+| 17:30 - 18:10 | How to survive managing Strimzi in an enterprise (Richard Bosch, @ Axual BV) | Support Tiered Storage in Strimzi operated Kafka (Lixin Yao, Vrishali Bhor, bo gao @ Apple) |
 
 You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/) as part of the CNCF events.
 

--- a/_posts/2024-04-08-strimzicon2024-schedule.md
+++ b/_posts/2024-04-08-strimzicon2024-schedule.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title:  "StrimziCon 2024: schedule announced!"
+date: 2024-04-08
+author: paolo_patierno
+---
+
+We are very pleased to announce the speakers and sessions for the first StrimziCon!
+The interest from the community was really high and we received a lot of awesome proposals.
+The program committee had really tough times to choose among them in order to build an amazing agenda.
+
+<!--more-->
+
+![StrimziCon 2024 Banner](/assets/images/posts/2024-01-29-strimzicon2024-banner.png)
+
+### Awesome sessions ... join the StrimziCon! 
+
+The conference will take place on <b>Wednesday, May 22nd</b> (afternoon CEST), with two parallel tracks in the "River" and "Waterfall" virtual rooms.
+It will start with a keynote with Kate Stanley (Red Hat) and Paolo Patierno (Red Hat, Strimzi maintainer) talking about Strimzi, its current status and the future roadmap together with the Apache Kafka project.
+The keynote will be followed by 3 hours of breakout sessions covering several topics from core Strimzi features, to use cases and integrations.
+
+| Time | River room | Waterfall room |
+|:---:|:---:|:---:|
+| 14:30 - 14:50 | Keynote (Kate Stanley & Paolo Patierno @Red Hat) | Keynote (Kate Stanley & Paolo Patierno @Red Hat) |
+| 15:00 - 15:40 | Upgrade yourself to the Business Class (Jakub Scholz @Red Hat) | Exploring Strimzi’s implementation of rolling updates (Gantigmaa Selenge @Red Hat) |
+| 15:50 - 16:30 | Transition to Apache Kafka on Kubernetes with Strimzi (Steffen Wirenfeldt Karlsson @Maersk) | Modernizing Nubank's Kafka Platform For The Next 10 Years Starting at 1 Trillion Messages per Month (Julio Turolla, Roni Silva @Nubank) |
+| 16:40 - 17:20 | Enhancing Kafka Topic Management in Kubernetes with the Unidirectional Topic Operator (Federico Valeri @Red Hat) | Partial Multi-Tenancy on Kafka using Strimzi at LittleHorse (Colt McNealy @LittleHorse) |
+| 17:30 - 18:10 | How to survive managing Strimzi in an enterprise (Richard Bosch, @Axual BV) | Support Tiered Storage in Strimzi operated Kafka (Lixin Yao, Vrishali Bhor, bo gao @Apple) |
+
+You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/) as part of the CNCF events.
+
+Looking forward to see you at the conference and remember to register ... it's free!

--- a/_posts/2024-04-08-strimzicon2024-schedule.md
+++ b/_posts/2024-04-08-strimzicon2024-schedule.md
@@ -29,4 +29,4 @@ The keynote will be followed by 3 hours of breakout sessions covering several to
 
 You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/) as part of the CNCF events.
 
-Looking forward to see you at the conference and remember to register ... it's free!
+Looking forward to see you at the conference and remember to [register](https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/) ... it's free!

--- a/_posts/2024-04-09-strimzicon2024-schedule.md
+++ b/_posts/2024-04-09-strimzicon2024-schedule.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "StrimziCon 2024: Schedule announced!"
-date: 2024-04-08
+date: 2024-04-09
 author: paolo_patierno
 ---
 

--- a/_posts/2024-04-09-strimzicon2024-schedule.md
+++ b/_posts/2024-04-09-strimzicon2024-schedule.md
@@ -25,7 +25,7 @@ The keynote will be followed by 3 hours of breakout sessions covering several to
 | 15:00 - 15:40 | Upgrade yourself to the Business Class (Jakub Scholz @ Red Hat) | Exploring Strimzi’s implementation of rolling updates (Gantigmaa Selenge @ Red Hat) |
 | 15:50 - 16:30 | Transition to Apache Kafka on Kubernetes with Strimzi (Steffen Wirenfeldt Karlsson @ Maersk) | Modernizing Nubank's Kafka Platform For The Next 10 Years Starting at 1 Trillion Messages per Month (Julio Turolla, Roni Silva @ Nubank) |
 | 16:40 - 17:20 | Enhancing Kafka Topic Management in Kubernetes with the Unidirectional Topic Operator (Federico Valeri @ Red Hat) | Partial Multi-Tenancy on Kafka using Strimzi at LittleHorse (Colt McNealy @ LittleHorse) |
-| 17:30 - 18:10 | How to survive managing Strimzi in an enterprise (Richard Bosch, @ Axual BV) | Support Tiered Storage in Strimzi operated Kafka (Lixin Yao, Vrishali Bhor, bo gao @ Apple) |
+| 17:30 - 18:10 | How to survive managing Strimzi in an enterprise (Richard Bosch, @ Axual BV) | Support Tiered Storage in Strimzi operated Kafka (Lixin Yao, Vrishali Bhor, Bo Gao @ Apple) |
 
 You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/) as part of the CNCF events.
 

--- a/_posts/2024-04-09-strimzicon2024-schedule.md
+++ b/_posts/2024-04-09-strimzicon2024-schedule.md
@@ -7,7 +7,7 @@ author: paolo_patierno
 
 We are very pleased to announce the speakers and sessions for the first StrimziCon!
 The interest from the community was really high and we received a lot of awesome proposals.
-The program committee had really tough times to choose among them in order to build an amazing agenda.
+The program committee found it really tough to choose among them in order to build an amazing agenda.
 
 <!--more-->
 
@@ -16,12 +16,12 @@ The program committee had really tough times to choose among them in order to bu
 ### Awesome sessions ... join the StrimziCon! 
 
 The conference will take place on <b>Wednesday, May 22nd</b> (afternoon CEST), with two parallel tracks in the "River" and "Waterfall" virtual rooms.
-It will start with a keynote with Kate Stanley (Red Hat) and Paolo Patierno (Red Hat, Strimzi maintainer) talking about Strimzi, its current status and the future roadmap together with the Apache Kafka project.
+It will start with a keynote from Kate Stanley (Red Hat) and Paolo Patierno (Red Hat, Strimzi maintainer) talking about Strimzi, its current status and the future roadmap together with the Apache Kafka project.
 The keynote will be followed by 3 hours of breakout sessions covering several topics from core Strimzi features, to use cases and integrations.
 
-| Time | River room | Waterfall room |
+| Time (CEST) | River room | Waterfall room |
 |:---:|:---:|:---:|
-| 14:30 - 14:50 | Keynote (Kate Stanley & Paolo Patierno @ Red Hat) | Keynote (Kate Stanley & Paolo Patierno @ Red Hat) |
+| 14:30 - 14:50 | Keynote (Kate Stanley & Paolo Patierno @ Red Hat) | |
 | 15:00 - 15:40 | Upgrade yourself to the Business Class (Jakub Scholz @ Red Hat) | Exploring Strimzi’s implementation of rolling updates (Gantigmaa Selenge @ Red Hat) |
 | 15:50 - 16:30 | Transition to Apache Kafka on Kubernetes with Strimzi (Steffen Wirenfeldt Karlsson @ Maersk) | Modernizing Nubank's Kafka Platform For The Next 10 Years Starting at 1 Trillion Messages per Month (Julio Turolla, Roni Silva @ Nubank) |
 | 16:40 - 17:20 | Enhancing Kafka Topic Management in Kubernetes with the Unidirectional Topic Operator (Federico Valeri @ Red Hat) | Partial Multi-Tenancy on Kafka using Strimzi at LittleHorse (Colt McNealy @ LittleHorse) |
@@ -29,4 +29,4 @@ The keynote will be followed by 3 hours of breakout sessions covering several to
 
 You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/) as part of the CNCF events.
 
-Looking forward to see you at the conference and remember to [register](https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/) ... it's free!
+Looking forward to seeing you at the conference and remember to [register](https://community.cncf.io/events/details/cncf-virtual-project-events-2024-hosted-by-cncf-presents-strimzicon-2024-virtual/) ... it's free!


### PR DESCRIPTION
This PR adds a blog post about announcing the StrimziCon 2024 schedule.
