### PR TITLE
Use KRaft in the Quickstart example

### DIFF
--- a/_includes/quickstarts/create-commands.md
+++ b/_includes/quickstarts/create-commands.md
@@ -31,11 +31,11 @@ Once the operator is running it will watch for new custom resources and create t
 
 # Create an Apache Kafka cluster
 
-Create a new Kafka custom resource to get a small persistent Apache Kafka Cluster with one node for Apache Zookeeper and Apache Kafka:
+Create a new Kafka custom resource to get a small persistent Apache Kafka Cluster with a one node:
 
 ```shell
 # Apply the `Kafka` Cluster CR file
-kubectl apply -f https://strimzi.io/examples/latest/kafka/kafka-persistent-single.yaml -n kafka 
+kubectl apply -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml -n kafka 
 ```
 
 Wait while Kubernetes starts the required pods, services, and so on:
@@ -58,7 +58,7 @@ Once everything is set up correctly, you'll see a prompt where you can type in y
 ```shell
 If you don't see a command prompt, try pressing enter.
 
->Hello strimzi!
+>Hello Strimzi!
 ```
 
 And to receive them in a different terminal, run:
@@ -70,5 +70,5 @@ If everything works as expected, you'll be able to see the message you produced 
 ```shell
 If you don't see a command prompt, try pressing enter.
 
->Hello strimzi!
+>Hello Strimzi!
 ```

--- a/_includes/quickstarts/create-commands.md
+++ b/_includes/quickstarts/create-commands.md
@@ -31,7 +31,7 @@ Once the operator is running it will watch for new custom resources and create t
 
 # Create an Apache Kafka cluster
 
-Create a new Kafka custom resource to get a small persistent Apache Kafka Cluster with a one node:
+Create a new Kafka custom resource to get a single node Apache Kafka cluster:
 
 ```shell
 # Apply the `Kafka` Cluster CR file

--- a/_includes/quickstarts/delete-commands.md
+++ b/_includes/quickstarts/delete-commands.md
@@ -8,10 +8,26 @@ kubectl -n kafka delete $(kubectl get strimzi -o name -n kafka)
 
 This will remove all Strimzi custom resources, including the Apache Kafka cluster and any KafkaTopic custom resources but leave the Strimzi cluster operator running so that it can respond to new Kafka custom resources.
 
+Next, delete the Persistent Volume Claim (PVC) that was used by the cluster:
+
+```shell
+kubectl delete pvc -l strimzi.io/name=my-cluster-kafka -n kafka
+```
+
+Without deleting the PVC, the next Kafka cluster you might start will fail as it will try to use the volume that belonged to the previous Apache Kafka cluster.
+
 # Deleting the Strimzi cluster operator
 
 When you want to fully remove the Strimzi cluster operator and associated definitions, you can run:
 
 ```shell
 kubectl -n kafka delete -f 'https://strimzi.io/install/latest?namespace=kafka'
+```
+
+# Deleting the `kafka` namespace
+
+Once it is not used, you can also delete the Kubernetes namespace:
+
+```shell
+kubectl delete namespace kafka
 ```


### PR DESCRIPTION
This PR updates the [Quickstarts](https://strimzi.io/quickstarts/) on our website to use KRaft instead of ZooKeeper based Kafka cluster. This should help to avoid the DNS issues related to ZooKeeper.