### PR TITLE
Add Drain Cleaner 1.2.0 to the Helm Chart index

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -2,6 +2,21 @@ apiVersion: v1
 entries:
   strimzi-drain-cleaner:
   - apiVersion: v2
+    appVersion: 1.2.0
+    created: "2024-08-07T01:19:22.9613+02:00"
+    description: Utility which helps with moving the Apache Kafka pods deployed by
+      Strimzi from Kubernetes nodes which are being drained.
+    digest: 1add7475693410403c29fc05b6725e0296c8ceeb4fc0e7c882b240758b7f7171
+    home: https://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
+    name: strimzi-drain-cleaner
+    sources:
+    - https://github.com/strimzi/drain-cleaner
+    type: application
+    urls:
+    - https://github.com/strimzi/drain-cleaner/releases/download/1.2.0/strimzi-drain-cleaner-helm-3-chart-1.2.0.tgz
+    version: 1.2.0
+  - apiVersion: v2
     appVersion: 1.1.0
     created: "2024-03-02T12:25:31.17711+01:00"
     description: Utility which helps with moving the Apache Kafka pods deployed by
@@ -1657,4 +1672,4 @@ entries:
     urls:
     - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
     version: 0.6.0
-generated: "2024-07-10T17:48:24.506398+02:00"
+generated: "2024-08-07T01:19:22.960589+02:00"


### PR DESCRIPTION
This PR adds Drain Cleaner 1.2.0 to the Helm Chart index on the website.