### PR TITLE
Add dedicated KRaft page summarizing various KRaft related information

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -1,5 +1,14 @@
 strimzi_presentations:
  - name: "Released From the Cage: Apache Kafka Without Its ZooKeeper"
+   info: DevConf.CZ 2024
+   video_url: https://youtu.be/LjQ-l-Yea9g
+ - name: "Growing out of StatefulSets"
+   info: KCD Czech & Slovak 2024
+   video_url: https://youtu.be/PiszQV9h-88
+ - name: "StrimziCon 2024 - session recordings"
+   info: StrimziCon 2024
+   video_url: https://www.youtube.com/playlist?list=PLpI4X8PMthYemH5ffnnOFLRhKpJiY1oAn
+ - name: "Released From the Cage: Apache Kafka Without Its ZooKeeper"
    info: DoK Day @ KubeCon Europe 2024
    video_url: https://youtu.be/74fDjwigLms
  - name: "Strimzi: Toward a ZooKeeper-less Future"

--- a/_includes/kraft/kraft-content.html
+++ b/_includes/kraft/kraft-content.html
@@ -1,0 +1,37 @@
+<div class="kraft-band">
+  <div class="component-slim grid-wrapper">
+    <div class="width-12-12">
+      <h2 class="blue" id="kraft-information-sources">KRaft information sources</h2>
+      
+      <h3 id="kraft-documentation">Documentation</h3>
+      
+      <ul>
+        <li><a href="https://strimzi.io/docs/operators/latest/deploying#assembly-kraft-mode-str">Using Kafka in KRaft mode</a></li>
+        <li><a href="https://strimzi.io/docs/operators/latest/deploying#deploying-kafka-cluster-kraft-str">Deploying a Kafka cluster in KRaft mode</a></li>
+        <li><a href="https://strimzi.io/docs/operators/latest/deploying#proc-deploy-migrate-kraft-str">Migrating to KRaft mode</a></li>
+      </ul>
+
+      <h3 id="kraft-blog-posts">Blog posts</h3>
+
+      <ul>
+        <li><a href="https://strimzi.io/blog/2024/08/21/taming-apache-kafka-4.0/">Taming Apache Kafka 4.0</a> (August 21st, 2024)</li>
+        <li><a href="https://strimzi.io/blog/2024/03/22/strimzi-kraft-migration/">Migrate your Strimzi-operated cluster from ZooKeeper to KRaft</a> (March 22nd, 2024)</li>
+        <li><a href="https://strimzi.io/blog/2024/03/21/kraft-migration/">From ZooKeeper to KRaft: How the Kafka migration works</a> (March 21st, 2024)</li>
+        <li><a href="https://strimzi.io/blog/2023/11/02/unidirectional-topic-operator/">Introducing the Unidirectional Topic Operator</a> (November 2nd, 2023)</li>
+        <li><a href="https://strimzi.io/blog/2023/09/11/kafka-node-pools-supporting-kraft/">Kafka Node Pools: Supporting KRaft (ZooKeeper-less Apache Kafka)</a> (September 11th, 2023)</li>
+      </ul>
+
+      <h3 id="kraft-videos">Videos & Conferences</h3>
+
+      <ul>
+        <li><a href="https://youtu.be/CxTCgxiA2H8">Migrate your Kafka cluster from ZooKeeper to KRaft with Strimzi</a> (March 25th, 2024)</li>
+        <li><a href="https://youtu.be/LjQ-l-Yea9g">Released From the Cage: Apache Kafka Without Its ZooKeeper</a> (DevConf.CZ, Jun 15th, 2024)</li>
+        <li><a href="https://youtu.be/PiszQV9h-88">Growing out of StatefulSets</a> (KCD Czech & Slovak, Jun 7th, 2024)</li>
+        <li><a href="https://youtu.be/74fDjwigLms">Released From the Cage: Apache Kafka Without Its ZooKeeper</a> (DoK Day @ KubeCon, March 19th, 2024)</li>
+        <li><a href="https://youtu.be/_zpjMh8p02Y">Strimzi: Toward a ZooKeeper-less Future</a> (KubeCon EU, March 19th, 2024)</li>
+        <li><a href="https://youtu.be/mT7dbLNCGtQ">Road to KRaft: ZooKeeper-less Kafka in Strimzi 0.29.0</a> (May 26th, 2022)</li>
+      </ul>
+
+    </div>
+  </div>
+</div>

--- a/_includes/kraft/kraft-content.html
+++ b/_includes/kraft/kraft-content.html
@@ -3,15 +3,25 @@
     <div class="width-12-12">
       <h2 class="blue" id="kraft-information-sources">KRaft information sources</h2>
       
+      <p>This page lists the various information sources related to KRaft and ZooKeeper removal.
+        Please keep in mind that some of the information in the old videos and blog posts migth be out of date.
+        You should always check the documentation for your Strimzi version that should be always up-to-date.</p>
+
       <h3 id="kraft-documentation">Documentation</h3>
       
+      <p>The following documentation sections cover KRaft, its use and migration of ZooKeeper-based clusters to KRaft:</p>
+
       <ul>
         <li><a href="https://strimzi.io/docs/operators/latest/deploying#assembly-kraft-mode-str">Using Kafka in KRaft mode</a></li>
         <li><a href="https://strimzi.io/docs/operators/latest/deploying#deploying-kafka-cluster-kraft-str">Deploying a Kafka cluster in KRaft mode</a></li>
         <li><a href="https://strimzi.io/docs/operators/latest/deploying#proc-deploy-migrate-kraft-str">Migrating to KRaft mode</a></li>
       </ul>
 
+      <p></p>
+
       <h3 id="kraft-blog-posts">Blog posts</h3>
+
+      <p>The following blog posts cover KRaft and ZooKeeper removal:</p>
 
       <ul>
         <li><a href="https://strimzi.io/blog/2024/08/21/taming-apache-kafka-4.0/">Taming Apache Kafka 4.0</a> (August 21st, 2024)</li>
@@ -21,7 +31,11 @@
         <li><a href="https://strimzi.io/blog/2023/09/11/kafka-node-pools-supporting-kraft/">Kafka Node Pools: Supporting KRaft (ZooKeeper-less Apache Kafka)</a> (September 11th, 2023)</li>
       </ul>
 
+      <p></p>
+
       <h3 id="kraft-videos">Videos & Conferences</h3>
+
+      <p>The following videos and conference talks cover KRaft and ZooKeeper removal:</p>
 
       <ul>
         <li><a href="https://youtu.be/CxTCgxiA2H8">Migrate your Kafka cluster from ZooKeeper to KRaft with Strimzi</a> (March 25th, 2024)</li>
@@ -31,6 +45,8 @@
         <li><a href="https://youtu.be/_zpjMh8p02Y">Strimzi: Toward a ZooKeeper-less Future</a> (KubeCon EU, March 19th, 2024)</li>
         <li><a href="https://youtu.be/mT7dbLNCGtQ">Road to KRaft: ZooKeeper-less Kafka in Strimzi 0.29.0</a> (May 26th, 2022)</li>
       </ul>
+
+      <p></p>
 
     </div>
   </div>

--- a/_includes/kraft/kraft-content.html
+++ b/_includes/kraft/kraft-content.html
@@ -3,13 +3,13 @@
     <div class="width-12-12">
       <h2 class="blue" id="kraft-information-sources">KRaft information sources</h2>
       
-      <p>This page lists the various information sources related to KRaft and ZooKeeper removal.
-        Please keep in mind that some of the information in the old videos and blog posts migth be out of date.
-        You should always check the documentation for your Strimzi version that should be always up-to-date.</p>
+      <p>This page lists information sources related to KRaft adoption and ZooKeeper removal.
+        Please keep in mind that some of the information in the old videos and blog posts might be out of date.
+        Always refer to the documentation for your Strimzi version, which is regularly updated to provide the latest information.</p>
 
       <h3 id="kraft-documentation">Documentation</h3>
       
-      <p>The following documentation sections cover KRaft, its use and migration of ZooKeeper-based clusters to KRaft:</p>
+      <p>The following documentation sections cover using KRaft and migration from ZooKeeper-based clusters:</p>
 
       <ul>
         <li><a href="https://strimzi.io/docs/operators/latest/deploying#assembly-kraft-mode-str">Using Kafka in KRaft mode</a></li>
@@ -21,7 +21,7 @@
 
       <h3 id="kraft-blog-posts">Blog posts</h3>
 
-      <p>The following blog posts cover KRaft and ZooKeeper removal:</p>
+      <p>The following blog posts cover KRaft adoption and ZooKeeper removal:</p>
 
       <ul>
         <li><a href="https://strimzi.io/blog/2024/08/21/taming-apache-kafka-4.0/">Taming Apache Kafka 4.0</a> (August 21st, 2024)</li>
@@ -35,7 +35,7 @@
 
       <h3 id="kraft-videos">Videos & Conferences</h3>
 
-      <p>The following videos and conference talks cover KRaft and ZooKeeper removal:</p>
+      <p>The following videos and conference talks cover KRaft adoption and ZooKeeper removal:</p>
 
       <ul>
         <li><a href="https://youtu.be/CxTCgxiA2H8">Migrate your Kafka cluster from ZooKeeper to KRaft with Strimzi</a> (March 25th, 2024)</li>

--- a/_includes/kraft/kraft-title-band.html
+++ b/_includes/kraft/kraft-title-band.html
@@ -1,0 +1,10 @@
+<div class="secondary-page-title-band">
+  <div class="pattern-wrapper-light">
+    <div class="component-slim grid-wrapper">
+      <div class="width-12-12">
+        <h1>KRaft / ZooKeeper removal</h1>
+        <h3>List of information sources about KRaft support / ZooKeeper removal</h3>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/kraft/kraft-title-band.html
+++ b/_includes/kraft/kraft-title-band.html
@@ -2,8 +2,8 @@
   <div class="pattern-wrapper-light">
     <div class="component-slim grid-wrapper">
       <div class="width-12-12">
-        <h1>KRaft / ZooKeeper removal</h1>
-        <h3>List of information sources about KRaft support / ZooKeeper removal</h3>
+        <h1>KRaft adoption and ZooKeeper removal</h1>
+        <h3>Information related to the transition to KRaft</h3>
       </div>
     </div>
   </div>

--- a/_layouts/kraft.html
+++ b/_layouts/kraft.html
@@ -2,5 +2,5 @@
 layout: base
 ---
 
-{% include join-us/kraft-title-band.html %}
-{% include join-us/kraft-content.html %}
+{% include kraft/kraft-title-band.html %}
+{% include kraft/kraft-content.html %}

--- a/_layouts/kraft.html
+++ b/_layouts/kraft.html
@@ -1,0 +1,6 @@
+---
+layout: base
+---
+
+{% include join-us/kraft-title-band.html %}
+{% include join-us/kraft-content.html %}

--- a/kraft.md
+++ b/kraft.md
@@ -1,0 +1,5 @@
+---
+layout: kraft
+title: KRaft
+permalink: /kraft/
+---


### PR DESCRIPTION
This PR adds a new page dedicated to various information related to KRaft. The page is not directly linked anywhere. But it could be used for example in presentations or discussions to easily link to the blog posts, docs or videos. The preview of the page can be found here: https://deploy-preview-450--strimzi.netlify.app/kraft/

This PR also updates the list of presentations and conferences with some new talks.