### PR TITLE
Add Kafka Meetup Utrecht recording to presentations and to list of KRaft sources

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -1,4 +1,7 @@
 strimzi_presentations:
+ - name: "KRaft: Apache Kafka without its ZooKeeper"
+   info: Axual Kafka Meetup Utrecht (8th October 2024)
+   video_url: https://youtu.be/bM7YhKpSkBQ
  - name: "Released From the Cage: Apache Kafka Without Its ZooKeeper"
    info: DevConf.CZ 2024
    video_url: https://youtu.be/LjQ-l-Yea9g

--- a/_includes/kraft/kraft-content.html
+++ b/_includes/kraft/kraft-content.html
@@ -38,6 +38,7 @@
       <p>The following videos and conference talks cover KRaft adoption and ZooKeeper removal:</p>
 
       <ul>
+        <li><a href="https://youtu.be/bM7YhKpSkBQ">KRaft: Apache Kafka without its ZooKeeper</a> (Axual Kafka Meetup Utrecht, Oct 8th, 2024)</li>
         <li><a href="https://youtu.be/CxTCgxiA2H8">Migrate your Kafka cluster from ZooKeeper to KRaft with Strimzi</a> (March 25th, 2024)</li>
         <li><a href="https://youtu.be/LjQ-l-Yea9g">Released From the Cage: Apache Kafka Without Its ZooKeeper</a> (DevConf.CZ, Jun 15th, 2024)</li>
         <li><a href="https://youtu.be/PiszQV9h-88">Growing out of StatefulSets</a> (KCD Czech & Slovak, Jun 7th, 2024)</li>


### PR DESCRIPTION
This Pr adds the recording of my talk about ZooKeeper removal and KRaft from the Axual Kafka Meetup in Utrecht to the presentations and to the KRaft page (https://strimzi.io/kraft).