### PR TITLE
Replace the old Roadmap page with redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -45,3 +45,6 @@
 
 # Redirects for old community page
 /community/*                        /join-us/                                                                                                           301
+
+# Redirects for old roadmap page
+/roadmap/*                          https://github.com/orgs/strimzi/projects/4                                                                          301

--- a/roadmap/index.md
+++ b/roadmap/index.md
@@ -1,7 +1,0 @@
----
-layout: default
----
-
-# Roadmap
-
-The roadmap has been moved to a [GitHub project](https://github.com/strimzi/strimzi-kafka-operator/projects/1).


### PR DESCRIPTION
Turns out, that we have the old Roadmap page on our website (https://strimzi.io/roadmap/), and still accessible through search engines. This PR replaces it with permanent redirect (HTTP 301). 