### PR TITLE
docs(docs): adds links to content related to drain cleaner and access operator

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -695,3 +695,7 @@ bridge:
   - version: 0.12.2
   - version: 0.12.1
   - version: 0.12.0
+drainCleaner:
+  - version: 1.2.0
+accessOperator:
+  - version: 0.1.0

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -18,6 +18,18 @@
         <a href="{{site.baseurl}}/docs/bridge/latest/">Strimzi Kafka Bridge documentation</a> <a href="/docs/bridge/latest/full.html" target="_blank"><i class="fas fa-external-link-alt"></i></a>
       </p>
       <p>
+        <strong class="text-caps">Strimzi Drain Cleaner {{site.data.releases.drainCleaner[0].version}}</strong>
+        <br/>
+        <a href="{{site.baseurl}}/docs/operators/latest/deploying.html#assembly-drain-cleaner-str">Evicting pods with the Strimzi Drain Cleaner</a> <a href="/docs/operators/latest/full/deploying.html#assembly-drain-cleaner-str" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+      </p>
+
+      <p>
+        <strong class="text-caps">Strimzi Access Operator {{site.data.releases.accessOperator[0].version}}</strong>
+        <br/>
+        <a href="{{site.baseurl}}/docs/operators/latest/deploying.html#assembly-access-operator-str">Managing client connections with the Access Operator</a> <a href="/docs/operators/latest/full/deploying.html#assembly-access-operator-str" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+      </p>
+
+      <p>
         <strong class="text-caps">Quickstarts</strong>
         <br/>
         Try the <a href="{{site.baseurl}}/quickstarts/">quickstarts</a> for quick and easy installations on different development environments.
@@ -41,6 +53,18 @@
       <strong class="text-caps">Strimzi Kafka Bridge</strong>
       <br/>
       <a href="{{site.baseurl}}/docs/bridge/in-development/">Strimzi Kafka Bridge documentation</a> <a href="/docs/bridge/in-development/full/bridge.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+      </p>
+
+      <p>
+        <strong class="text-caps">Strimzi Drain Cleaner</strong>
+        <br/>
+        <a href="{{site.baseurl}}/docs/operators/in-development/deploying.html#assembly-drain-cleaner-str">Evicting pods with the Strimzi Drain Cleaner</a> <a href="/docs/operators/in-development/full/deploying.html#assembly-drain-cleaner-str" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+      </p>
+
+      <p>
+        <strong class="text-caps">Strimzi Access Operator</strong>
+        <br/>
+        <a href="{{site.baseurl}}/docs/operators/in-development/deploying.html#assembly-access-operator-str">Managing client connections with the Access Operator</a> <a href="/docs/operators/in-development/full/deploying.html#assembly-access-operator-str" target="_blank"><i class="fas fa-external-link-alt"></i></a>
       </p>
    </div>
   </div>


### PR DESCRIPTION
**Documentation page**

Adds links to the Documentation page for content related to the Drain Cleaner and Access Operator

* [ ] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
