### PR TITLE
docs(docs): link fix for full bridge doc

### DIFF
--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -135,7 +135,7 @@
             <li><a href="/docs/operators/in-development/full/overview.html" target="_blank">Overview</a> <i class="fas fa-external-link-alt external"></i></li>
             <li><a href="/docs/operators/in-development/full/deploying.html" target="_blank">Deploying and Upgrading</a> <i class="fas fa-external-link-alt external"></i></li>
             <li><a href="/docs/operators/in-development/full/configuring.html" target="_blank">API Reference</a> <i class="fas fa-external-link-alt external"></i></li>
-            <li><a href="/docs/bridge/latest/full.html" target="_blank">Kafka Bridge documentation</a> <i class="fas fa-external-link-alt external"></i></li>
+            <li><a href="/docs/bridge/in-development/full/bridge.html" target="_blank">Kafka Bridge documentation</a> <i class="fas fa-external-link-alt external"></i></li>
           </ul>
         </details>
       </p>


### PR DESCRIPTION
**Documentation page**

Fixes link to point to _full_ bridge doc

* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
