### PR TITLE
Removed StrimziCon 2025 CFP banner

### DIFF
--- a/_includes/homepage/homepage-announcement-band.html
+++ b/_includes/homepage/homepage-announcement-band.html
@@ -1,8 +1,7 @@
 <div class="component-slim announcement_orange">
   <div class="grid-wrapper">
     <div class="width-12-12">
-      <p>Don't miss out on your chance to shine at <a href="https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-2025-virtual/">StrimziCon</a> in June!
-        The <a href="https://sessionize.com/strimzicon-2025/">Call for Papers</a> closes on March 16th.</p>
+      <p>Placeholder for an announcement</p>
     </div>
   </div>
 </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,7 +1,9 @@
 ---
 layout: base
 ---
-{% include homepage/homepage-announcement-band.html %}
+{% comment %}
+    {% include homepage/homepage-announcement-band.html %}
+{% endcomment %}
 {% include homepage/homepage-hero-band.html %}
 {% include homepage/homepage-download-announcement-band.html %}
 {% include homepage/homepage-zoom-band.html %}


### PR DESCRIPTION
This PR removes the banner announcement related to StrimziCon 2025 CFP which was closed on March 16th.