### PR TITLE
Added blog post about StrimziCon 2025 schedule

### DIFF
--- a/_posts/2025-04-16-strimzicon2025-schedule.md
+++ b/_posts/2025-04-16-strimzicon2025-schedule.md
@@ -13,9 +13,9 @@ The program committee found it really tough to choose among them in order to bui
 
 ![StrimziCon 2025 Banner](/assets/images/posts/2025-01-29-strimzicon2025-banner.png)
 
-### Awesome sessions ... join the StrimziCon! 
+### Awesome sessions ... join StrimziCon! 
 
-The conference will take place on <b>Wednesday, June 4th</b> (afternoon CEST).
+The conference will take place on <b>Wednesday, June 4th, 2025</b> (afternoon CEST).
 It will start with a keynote from Kate Stanley (Red Hat, Strimzi maintainer) and Paolo Patierno (Red Hat, Strimzi maintainer) talking about Strimzi, its current status and the future roadmap together with the Apache Kafka project.
 The keynote will be followed by 5 hours of breakout sessions covering several topics from core Strimzi features, to use cases and integrations.
 
@@ -32,4 +32,4 @@ The keynote will be followed by 5 hours of breakout sessions covering several to
 
 You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-2025-virtual/) as part of the CNCF events.
 
-Looking forward to seeing you at the conference and remember to [register](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-2025-virtual/) ... it's free!
+Looking forward to seeing you at the conference and don't forget to [register](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-2025-virtual/). It's free!

--- a/_posts/2025-04-16-strimzicon2025-schedule.md
+++ b/_posts/2025-04-16-strimzicon2025-schedule.md
@@ -1,0 +1,35 @@
+---
+layout: post
+title:  "StrimziCon 2025: Schedule announced!"
+date: 2025-04-16
+author: paolo_patierno
+---
+
+We are very pleased to announce the speakers and sessions for the second edition of StrimziCon!
+The interest from the community was really high and we received a lot of awesome proposals.
+The program committee found it really tough to choose among them in order to build an amazing agenda.
+
+<!--more-->
+
+![StrimziCon 2025 Banner](/assets/images/posts/2025-01-29-strimzicon2025-banner.png)
+
+### Awesome sessions ... join the StrimziCon! 
+
+The conference will take place on <b>Wednesday, June 4th</b> (afternoon CEST).
+It will start with a keynote from Kate Stanley (Red Hat, Strimzi maintainer) and Paolo Patierno (Red Hat, Strimzi maintainer) talking about Strimzi, its current status and the future roadmap together with the Apache Kafka project.
+The keynote will be followed by 5 hours of breakout sessions covering several topics from core Strimzi features, to use cases and integrations.
+
+| Time (CEST) | Session |
+|:---:|:---:|
+| 14:00 - 14:20 | Keynote (Kate Stanley & Paolo Patierno @ Red Hat) |
+| 14:30 - 15:00 | Phased upgrades of Strimzi managed Kafka fleets (Thomas Cooper @ Red Hat) |
+| 15:10 - 15:40 | Stretching Strimzi: Exploring Multi-Cluster Kafka for High Availability (Aswin A @ IBM) |
+| 15:50 - 16:20 | Strimzi & OpenTelemetry: Building End-to-End Observability for Kafka on Kubernetes (Neel Shah @ Middleware.io) |
+| 16:30 - 17:00 | When GitOps goes wrong, and other challenges for Strimzi platform teams (Björn Löfroth @ Irori AB) |
+| 17:10 - 17:40 | Improving Kafka monitoring with native Prometheus Metrics Reporter (Owen Corrigan, Federico Valeri, Mickael Maison @ Red Hat) |
+| 17:50 - 18:20 | Cost Efficient Network for Strimzi Kafka Operator (Haochen Li, Mingdi Mao, Chongling Zhu @ Apple) |
+| 18:30 - 19:00 | Managing a Kafka cluster in KRaft mode with Strimzi (Gantigmaa Selenge @ Red Hat) |
+
+You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-2025-virtual/) as part of the CNCF events.
+
+Looking forward to seeing you at the conference and remember to [register](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-2025-virtual/) ... it's free!


### PR DESCRIPTION
This PR adds a blog post related to the StrimziCon 2025 schedule announcement.