### PR TITLE
Fix strimzi/strimzi-kafka-operator#11418:  broken link to kraft with 0.46.0 update

### DIFF
--- a/_includes/quickstarts/create-commands.md
+++ b/_includes/quickstarts/create-commands.md
@@ -35,7 +35,7 @@ Create a new Kafka custom resource to get a single node Apache Kafka cluster:
 
 ```shell
 # Apply the `Kafka` Cluster CR file
-kubectl apply -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml -n kafka 
+kubectl apply -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml -n kafka 
 ```
 
 Wait while Kubernetes starts the required pods, services, and so on:

--- a/docs/operators/0.46.0/deploying-book.html
+++ b/docs/operators/0.46.0/deploying-book.html
@@ -2930,23 +2930,23 @@ You can also deploy and use other Kafka components with a Kafka cluster not mana
 </div>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><code>kafka/kraft/kafka-with-dual-role-nodes.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-with-dual-role-nodes.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with one pool of nodes that share the broker and controller roles.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-persistent.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-persistent.yaml</code></dt>
 <dd>
 <p>Deploys a persistent Kafka cluster with one pool of controller nodes and one pool of broker nodes.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-ephemeral.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-ephemeral.yaml</code></dt>
 <dd>
 <p>Deploys an ephemeral Kafka cluster with one pool of controller nodes and one pool of broker nodes.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-single-node.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-single-node.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with a single node.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-jbod.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-jbod.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with multiple volumes in each broker node.</p>
 </dd>

--- a/docs/operators/0.46.0/full/deploying.html
+++ b/docs/operators/0.46.0/full/deploying.html
@@ -3372,23 +3372,23 @@ You can also deploy and use other Kafka components with a Kafka cluster not mana
 </div>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><code>kafka/kraft/kafka-with-dual-role-nodes.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-with-dual-role-nodes.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with one pool of nodes that share the broker and controller roles.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-persistent.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-persistent.yaml</code></dt>
 <dd>
 <p>Deploys a persistent Kafka cluster with one pool of controller nodes and one pool of broker nodes.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-ephemeral.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-ephemeral.yaml</code></dt>
 <dd>
 <p>Deploys an ephemeral Kafka cluster with one pool of controller nodes and one pool of broker nodes.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-single-node.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-single-node.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with a single node.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-jbod.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-jbod.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with multiple volumes in each broker node.</p>
 </dd>

--- a/docs/operators/latest/deploying-book.html
+++ b/docs/operators/latest/deploying-book.html
@@ -2930,23 +2930,23 @@ You can also deploy and use other Kafka components with a Kafka cluster not mana
 </div>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><code>kafka/kraft/kafka-with-dual-role-nodes.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-with-dual-role-nodes.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with one pool of nodes that share the broker and controller roles.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-persistent.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-persistent.yaml</code></dt>
 <dd>
 <p>Deploys a persistent Kafka cluster with one pool of controller nodes and one pool of broker nodes.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-ephemeral.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-ephemeral.yaml</code></dt>
 <dd>
 <p>Deploys an ephemeral Kafka cluster with one pool of controller nodes and one pool of broker nodes.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-single-node.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-single-node.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with a single node.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-jbod.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-jbod.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with multiple volumes in each broker node.</p>
 </dd>

--- a/docs/operators/latest/full/deploying.html
+++ b/docs/operators/latest/full/deploying.html
@@ -3372,23 +3372,23 @@ You can also deploy and use other Kafka components with a Kafka cluster not mana
 </div>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><code>kafka/kraft/kafka-with-dual-role-nodes.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-with-dual-role-nodes.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with one pool of nodes that share the broker and controller roles.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-persistent.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-persistent.yaml</code></dt>
 <dd>
 <p>Deploys a persistent Kafka cluster with one pool of controller nodes and one pool of broker nodes.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-ephemeral.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-ephemeral.yaml</code></dt>
 <dd>
 <p>Deploys an ephemeral Kafka cluster with one pool of controller nodes and one pool of broker nodes.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-single-node.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-single-node.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with a single node.</p>
 </dd>
-<dt class="hdlist1"><code>kafka/kraft/kafka-jbod.yaml</code></dt>
+<dt class="hdlist1"><code>kafka/kafka-jbod.yaml</code></dt>
 <dd>
 <p>Deploys a Kafka cluster with multiple volumes in each broker node.</p>
 </dd>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other

With 0.46.0 update, it appears the `examples/kafka/kraft` folder from https://github.com/strimzi/strimzi-kafka-operator was removed.

This PR fixes the doc links for 0.46.0, in-development and latest folder from this repo.

Fixes https://github.com/strimzi/strimzi-kafka-operator/issues/11418