### PR TITLE
docs(site): updates github issues links to be for all projects

### DIFF
--- a/_includes/join-us/join-us-contribute-to-strimzi-band.html
+++ b/_includes/join-us/join-us-contribute-to-strimzi-band.html
@@ -69,13 +69,13 @@
           <i class="fas fa-arrow-right arrow"></i>
         </a>
 
-        <a class="tile" href="https://github.com/strimzi/strimzi-kafka-operator/issues?q=is%3Aopen+label%3Agood-start" target="_blank" rel="noopener noreferrer">
+        <a class="tile" href="https://github.com/search?q=org%3Astrimzi+label%3Agood-start+is%3Aopen&type=issues&s=created&o=asc" target="_blank" rel="noopener noreferrer">
           <h6>Pick your first issue</em></h6>
           <p>Start contributing by picking up an issue labeled <em>good start</em></p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
 
-        <a class="tile" href="https://github.com/strimzi/strimzi-kafka-operator/issues" target="_blank" rel="noopener noreferrer">
+        <a class="tile" href="https://github.com/search?q=org%3Astrimzi+is%3Aopen&type=issues&s=created&o=asc" target="_blank" rel="noopener noreferrer">
           <h6>Explore open issues</h6>
           <p>Browse all bugs, enhancements, and feature requests on GitHub</p>
           <i class="fas fa-arrow-right arrow"></i>
@@ -115,7 +115,7 @@
 
         <a class="tile" href="https://github.com/strimzi/strimzi-kafka-operator/issues/new/choose" target="_blank" rel="noopener noreferrer">
           <h6>Provide feedback</h6>
-          <p>Share ideas, report bugs, suggest improvements, or request new features on GitHub</p>
+          <p>Raise GitHub issues against specific Strimzi projects, share ideas, report bugs, suggest improvements, or request features</p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
 


### PR DESCRIPTION
Updates the links to github issues to encompass all strimzi projects

* [ ] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
