### PR TITLE
docs(site): align items on join us page

### DIFF
--- a/_includes/get-help/get-help-options.html
+++ b/_includes/get-help/get-help-options.html
@@ -68,7 +68,7 @@
       <hr class="section-divider">
 
       <!-- Asking questions -->
-      <h3 style="display: flex; align-items: center; gap: 0.5em;">
+      <h3 id="ask-the-community" style="display: flex; align-items: center; gap: 0.5em;">
         <img src="/assets/images/community/community_icon_question.svg" alt="" aria-hidden="true" style="height: 1.4em;">
         Ask the community
       </h3>

--- a/_includes/join-us/join-us-contribute-to-strimzi-band.html
+++ b/_includes/join-us/join-us-contribute-to-strimzi-band.html
@@ -24,6 +24,11 @@
         <img src="/assets/images/community/community_icon_chatroom.svg" alt="" aria-hidden="true" style="height: 1.4em;">
         Connect
       </h3>
+
+      <p>
+        You can connect with the Strimzi community in many ways — through Slack, community calls, social channels, 
+        or by using the <a href="/get-help/#ask-the-community">mailing lists and discussion forums</a> that help keep the community connected.
+      </p>
       
       <div class="grid-container">
 
@@ -48,6 +53,12 @@
         <a class="tile" href="https://twitter.com/strimziio" target="_blank" rel="noopener noreferrer">
           <h6><i class="fa-brands fa-x-twitter" aria-hidden="true" style="margin-right: 0.4em; text-decoration: none;"></i>Follow on X</h6>          
           <p>Follow us on X (formerly Twitter) and share your Strimzi story</p>
+          <i class="fas fa-arrow-right arrow"></i>
+        </a>
+
+        <a class="tile" href="https://www.youtube.com/playlist?list=PLpI4X8PMthYeCSpy9a-mGtvDbMgqGNYNy" target="_blank" rel="noopener noreferrer">
+          <h6><i class="fa-brands fa-youtube" aria-hidden="true" style="margin-right: 0.4em; text-decoration: none;"></i>Watch video tutorials</h6>
+          <p>Connect with Strimzi's YouTube channel and explore walkthroughs and demos</p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
 
@@ -87,30 +98,36 @@
           <i class="fas fa-arrow-right arrow"></i>
         </a>
 
-        <a class="tile" href="https://github.com/strimzi/strimzi-kafka-operator/blob/main/ADOPTERS.md" target="_blank" rel="noopener noreferrer">
-          <h6>Showcase your adoption</h6>
-          <p>Let others know you use Strimzi in production by adding your company to the official adopters list</p>
-          <i class="fas fa-arrow-right arrow"></i>
-        </a>
-
         <a class="tile" href="/grow-your-role/" target="_blank" rel="noopener noreferrer">
           <h6>Grow your role</h6>
           <p>Learn how contributors can take on more responsibility as component owners and maintainers</p>
           <i class="fas fa-arrow-right arrow"></i>
-        </a>               
+        </a>  
+        
+        <a class="tile" href="https://github.com/strimzi/proposals" target="_blank" rel="noopener noreferrer">
+          <h6>Propose enhancements</h6>
+          <p>Review or submit proposals to shape the future of the project</p>
+          <i class="fas fa-arrow-right arrow"></i>
+        </a>
 
       </div>
 
       <hr class="section-divider">
 
       <!-- Share knowledge -->
-      <p> Helping others is a valuable way to contribute. If you’ve solved a problem or learned something new, consider answering questions on Slack or GitHub, improving the docs, or writing a blog post to share your insights. </p>
-
+  
       <h3 style="display: flex; align-items: center; gap: 0.5em;">
         <img src="/assets/images/community/community_icon_editdocs.svg" alt="" aria-hidden="true" style="height: 1.4em;">
         Share
       </h3>
       
+      <p>
+        Helping others is a valuable way to contribute. If you’ve solved a problem or learned something new, consider 
+        <a href="/get-help/#ask-the-community">supporting others in the community</a> 
+        on Slack or GitHub discussions, improving the docs, or writing a blog post to share your experience.
+      </p>
+ 
+
       <div class="grid-container">
 
         <a class="tile" href="https://github.com/strimzi/strimzi-kafka-operator/issues/new/choose" target="_blank" rel="noopener noreferrer">
@@ -125,9 +142,9 @@
           <i class="fas fa-arrow-right arrow"></i>
         </a>
 
-        <a class="tile" href="https://github.com/strimzi/proposals" target="_blank" rel="noopener noreferrer">
-          <h6>Propose enhancements</h6>
-          <p>Review or submit proposals to shape the future of the project</p>
+        <a class="tile" href="https://github.com/strimzi/strimzi-kafka-operator/blob/main/ADOPTERS.md" target="_blank" rel="noopener noreferrer">
+          <h6>Showcase your adoption</h6>
+          <p>Let others know you use Strimzi in production by adding your company to the official adopters list</p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
 


### PR DESCRIPTION
**_Join Us_ page updates**

Aligns themes better by category by moving/adding a couple of tiles
Mentions mailing lists and discussions with links to relevant content on the _Get Help_ page.

* [ ] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
