### PR TITLE
Removed banner for StrimziCon 2025 registration

### DIFF
--- a/_includes/homepage/homepage-announcement-band.html
+++ b/_includes/homepage/homepage-announcement-band.html
@@ -1,7 +1,7 @@
 <div class="component-slim announcement_orange">
   <div class="grid-wrapper">
     <div class="width-12-12">
-      <p>Join us for StrimziCon: a virtual conference about the Strimzi project on June 4th. <a href="https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-2025-virtual/">Register now</a>!</p>
+      <p>Placeholder for an announcement</p>
     </div>
   </div>
 </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,7 +1,9 @@
 ---
 layout: base
 ---
-{% include homepage/homepage-announcement-band.html %}
+{% comment %}
+    {% include homepage/homepage-announcement-band.html %}
+{% endcomment %}
 {% include homepage/homepage-hero-band.html %}
 {% include homepage/homepage-download-announcement-band.html %}
 {% include homepage/homepage-zoom-band.html %}


### PR DESCRIPTION
This trivial PR removes the banner with the StrimziCon 2025 registration.