### PR TITLE
Fix heading levels in Quickstarts

### DIFF
--- a/_includes/quickstarts/create-commands.md
+++ b/_includes/quickstarts/create-commands.md
@@ -1,4 +1,4 @@
-# Deploy Strimzi using installation files
+### Deploy Strimzi using installation files
 
 Before deploying the Strimzi cluster operator, create a namespace called `kafka`:
 
@@ -29,7 +29,7 @@ kubectl logs deployment/strimzi-cluster-operator -n kafka -f
 
 Once the operator is running it will watch for new custom resources and create the Kafka cluster, topics or users that correspond to those custom resources.
 
-# Create an Apache Kafka cluster
+### Create an Apache Kafka cluster
 
 Create a new Kafka custom resource to get a single node Apache Kafka cluster:
 
@@ -46,7 +46,7 @@ kubectl wait kafka/my-cluster --for=condition=Ready --timeout=300s -n kafka
 
 The above command might timeout if you're downloading images over a slow connection. If that happens you can always run it again.
 
-# Send and receive messages
+### Send and receive messages
 
 With the cluster running, run a simple producer to send messages to a Kafka topic (the topic is automatically created):
 

--- a/_includes/quickstarts/delete-commands.md
+++ b/_includes/quickstarts/delete-commands.md
@@ -1,4 +1,4 @@
-# Deleting your Apache Kafka cluster
+### Deleting your Apache Kafka cluster
 
 When you are finished with your Apache Kafka cluster, you can delete it by running:
 
@@ -16,7 +16,7 @@ kubectl delete pvc -l strimzi.io/name=my-cluster-kafka -n kafka
 
 Without deleting the PVC, the next Kafka cluster you might start will fail as it will try to use the volume that belonged to the previous Apache Kafka cluster.
 
-# Deleting the Strimzi cluster operator
+### Deleting the Strimzi cluster operator
 
 When you want to fully remove the Strimzi cluster operator and associated definitions, you can run:
 
@@ -24,7 +24,7 @@ When you want to fully remove the Strimzi cluster operator and associated defini
 kubectl -n kafka delete -f 'https://strimzi.io/install/latest?namespace=kafka'
 ```
 
-# Deleting the `kafka` namespace
+### Deleting the `kafka` namespace
 
 Once it is not used, you can also delete the Kubernetes namespace:
 

--- a/_includes/quickstarts/next-steps.md
+++ b/_includes/quickstarts/next-steps.md
@@ -1,4 +1,4 @@
-# Where next?
+### Where next?
 
 * For an overview of the Strimzi components check out the [overview guide](/docs/operators/latest/overview.html).
 * For alternative examples of the custom resource that defines the Kafka cluster have a look at these [examples]({{site.github_url}}/strimzi-kafka-operator/tree/{{site.data.releases.operator[0].version}}/examples/kafka)

--- a/quickstarts/dockerdesktop.md
+++ b/quickstarts/dockerdesktop.md
@@ -1,7 +1,7 @@
 Docker Desktop includes a standalone Kubernetes server and client, designed for local testing of Kubernetes.
 You can start a Kubernetes cluster as a single-node cluster within a Docker container on your local system.
 
-# Installing the dependencies
+### Installing the dependencies
 
 This quickstart assumes that you have installed the latest version of Docker Desktop, which you can download from the [Docker website](https://docs.docker.com/desktop/).
 
@@ -15,7 +15,7 @@ After you have installed the binary, make sure it works:
 kubectl version
 ```
 
-# Starting the Kubernetes cluster
+### Starting the Kubernetes cluster
 
 Follow these steps to start a local development cluster of Kubernetes with [Docker Desktop](https://docs.docker.com/desktop/kubernetes/) which runs in a container on your local machine.
 

--- a/quickstarts/kind.md
+++ b/quickstarts/kind.md
@@ -8,7 +8,7 @@ For this reason it is faster to start, and consumes less CPU and RAM than the al
 
 _Note: Kubernetes Kind does currently not support node ports or load balancers. You will not be able to easily access your Kafka cluster from outside of the Kubernetes environment. If you need access from outside, we recommend to use Minikube instead._
 
-# Installing the dependencies
+### Installing the dependencies
 
 This quickstart assumes that you have the latest version of the `kind` binary, which you can get from the [Kind GitHub repository](https://github.com/kubernetes-sigs/kind/releases).
 
@@ -31,12 +31,12 @@ kind version
 kubectl version
 ```
 
-# Configuring the Docker daemon
+### Configuring the Docker daemon
 
 If your Docker Daemon runs as a VM you'll most likely need to configure how much memory the VM should have, how many CPUs, how much disk space, and swap size.
 Make sure to assign at least 2 CPUs, and preferably 4 Gb or more of RAM. Consult the Docker documentation for you platform how to configure these settings.
 
-# Starting the Kubernetes cluster
+### Starting the Kubernetes cluster
 
 Start a local development cluster of [Kubernetes Kind](https://github.com/kubernetes-sigs/kind) that installs as a single docker container.
 

--- a/quickstarts/minikube.md
+++ b/quickstarts/minikube.md
@@ -1,7 +1,7 @@
 Minikube provides a local Kubernetes, designed to make it easy to learn and develop for Kubernetes.
 The Kubernetes cluster is started either inside a virtual machine, a container or on bare-metal, depending on the minikube driver you choose.
 
-# Installing the dependencies
+### Installing the dependencies
 
 This quickstart assumes that you have the latest version of the `minikube` binary, which you can get from the [minikube website](https://minikube.sigs.k8s.io/docs/start/).
 
@@ -20,7 +20,7 @@ minikube version
 kubectl version
 ```
 
-# Starting the Kubernetes cluster
+### Starting the Kubernetes cluster
 
 Start a local development cluster of [Minikube](https://minikube.sigs.k8s.io/docs/start/) that runs in a container or virtual machine manager.
 


### PR DESCRIPTION
The heading levels in the Quickstarts are incorrectly used and render as many H1 headers in a single page. This PR tries to move them to a more suitable level.