### PR TITLE
Added StrimziCon 2025 recordings playlist to the presentations

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -1,4 +1,7 @@
 strimzi_presentations:
+ - name: "StrimziCon 2025 - session recordings"
+   info: StrimziCon 2025
+   video_url: https://youtube.com/playlist?list=PLpI4X8PMthYd-rxC90Her68tgRhIFbTAQ&feature=shared
  - name: "Apache Kafka on Kubernetes with Strimzi"
    info: Project Spotlight "Strimzi" at Cloud Native Club (21th November 2024)
    video_url: https://youtu.be/QrPJ3mgVkH8


### PR DESCRIPTION
This PR adds the link to the StrimziCon 2025 recordings playlist to the presentations section.
