### PR TITLE
Split users and vendors on the website

### DIFF
--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -38,6 +38,9 @@
         <img src="{{site.baseurl}}/assets/images/swisscom_logo.png" />
       </div>
       <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/randoli-logo.png" />
+      </div>
+      <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/alauda.logo.png" />
       </div>
       <div class="item__usedby">
@@ -75,9 +78,6 @@
       </div>
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/procure_ai_logo.png" />
-      </div>
-      <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/randoli-logo.png" />
       </div>
     </div>
 

--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -1,5 +1,21 @@
     <div class="width-12-12">
-      <h2 class="text-centered blue">Strimzi is used by</h2>
+      <h2 class="title__usedby">Strimzi vendors</h2>
+    </div>
+
+    <div class="container__usedby">
+      <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/redhat_logo.png" />
+      </div>
+      <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/axual_logo.png" />
+      </div>
+      <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/cloudera_logo.png" />
+      </div>
+    </div>
+
+    <div class="width-12-12">
+      <h2 class="title__usedby">Strimzi users</h2>
     </div>
 
     <div class="container__usedby">
@@ -7,12 +23,8 @@
         <img src="{{site.baseurl}}/assets/images/helvetia_logo.png" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/redhat_logo.png" />
-      </div>
-      <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/lightbend_logo.png" />
       </div>
-
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/grupomasmovil_logo.png" />
       </div>
@@ -22,17 +34,12 @@
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/swisscom_logo.png" />
       </div>
-
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/smart-ix-logo-colored-transparent.png" />
+        <img src="{{site.baseurl}}/assets/images/alauda.logo.png" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/axual_logo.png" />
+        <img src="{{site.baseurl}}/assets/images/skillsoft_logo.png" />
       </div>
-      <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/marlow-logo.svg" />
-      </div>
-
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/atruvia_logo_online_rgb.png" />
       </div>
@@ -42,7 +49,6 @@
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/procure_ai_logo.png" />
       </div>
-
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/littlehorse_logo.png" />
       </div>
@@ -50,9 +56,8 @@
         <img src="{{site.baseurl}}/assets/images/decathlon_digital_logo.svg" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/skillsoft_logo.png" />
+        <img src="{{site.baseurl}}/assets/images/smart-ix-logo-colored-transparent.png" />
       </div>
-
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/hetzner-logo-slogan_white_space-red.svg" />
       </div>
@@ -62,26 +67,21 @@
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/cozystack_logo.svg" />
       </div>
-
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/Reddit_Logo_Wordmark_OrangeRed.svg" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/alauda.logo.png" />
+        <img src="{{site.baseurl}}/assets/images/marlow-logo.svg" />
       </div>
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/randoli-logo.png" />
       </div>
-
-      <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/cloudera_logo.png" />
-      </div>
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/appsflyer_logo.svg" />
       </div>
-
     </div>
 
+  <hr class="section-divider">
   <div class="margin-tb-xl container__cnative">
     <div class="cnative__icon">
       <a href="https://cncf.io/" target="_blank">
@@ -92,6 +92,7 @@
         We are a <a href="https://cncf.io/" target="_blank">Cloud Native Computing Foundation</a> incubating project.
       </p>
   </div>
+
   <!--<div class="grid-wrapper">
     <div class="width-7-12 width-12-12-m align-self-center">
       <p class="text-centered margin-tb-0">

--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -1,23 +1,4 @@
     <div class="width-12-12">
-      <h2 class="title__usedby">Strimzi vendors</h2>
-    </div>
-
-    <div class="container__usedby">
-      <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/redhat_logo.png" />
-      </div>
-      <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/axual_logo.png" />
-      </div>
-      <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/cloudera_logo.png" />
-      </div>
-      <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/aenix_logo.svg" />
-      </div>
-    </div>
-
-    <div class="width-12-12">
       <h2 class="title__usedby">Strimzi users</h2>
     </div>
 
@@ -78,6 +59,25 @@
       </div>
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/marlow-logo.svg" />
+      </div>
+    </div>
+
+    <div class="width-12-12">
+      <h2 class="title__usedby">Strimzi vendors</h2>
+    </div>
+
+    <div class="container__usedby">
+      <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/redhat_logo.png" />
+      </div>
+      <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/axual_logo.png" />
+      </div>
+      <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/cloudera_logo.png" />
+      </div>
+      <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/aenix_logo.svg" />
       </div>
     </div>
 

--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -50,7 +50,7 @@
         <img src="{{site.baseurl}}/assets/images/baloise_logo.png" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/procure_ai_logo.png" />
+        <img src="{{site.baseurl}}/assets/images/appsflyer_logo.svg" />
       </div>
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/littlehorse_logo.png" />
@@ -74,10 +74,10 @@
         <img src="{{site.baseurl}}/assets/images/marlow-logo.svg" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/randoli-logo.png" />
+        <img src="{{site.baseurl}}/assets/images/procure_ai_logo.png" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/appsflyer_logo.svg" />
+        <img src="{{site.baseurl}}/assets/images/randoli-logo.png" />
       </div>
     </div>
 

--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -74,10 +74,10 @@
         <img src="{{site.baseurl}}/assets/images/Reddit_Logo_Wordmark_OrangeRed.svg" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/marlow-logo.svg" />
+        <img src="{{site.baseurl}}/assets/images/procure_ai_logo.png" />
       </div>
       <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/procure_ai_logo.png" />
+        <img src="{{site.baseurl}}/assets/images/marlow-logo.svg" />
       </div>
     </div>
 

--- a/_includes/homepage/homepage-usedby-band.html
+++ b/_includes/homepage/homepage-usedby-band.html
@@ -12,6 +12,9 @@
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/cloudera_logo.png" />
       </div>
+      <div class="item__usedby">
+        <img src="{{site.baseurl}}/assets/images/aenix_logo.svg" />
+      </div>
     </div>
 
     <div class="width-12-12">
@@ -60,9 +63,6 @@
       </div>
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/hetzner-logo-slogan_white_space-red.svg" />
-      </div>
-      <div class="item__usedby">
-        <img src="{{site.baseurl}}/assets/images/aenix_logo.svg" />
       </div>
       <div class="item__usedby">
         <img src="{{site.baseurl}}/assets/images/cozystack_logo.svg" />

--- a/_sass/strimzi.scss
+++ b/_sass/strimzi.scss
@@ -20,15 +20,22 @@ body:not(.homepage) {
   }
 }
 
+.title__usedby{
+  text-align: center;
+  color: #182C46;
+  margin: 3rem 0rem;
+}
+
 .container__usedby{
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  margin: 3rem 0rem;
   
   @media only screen and (max-width: 768px){
     flex-direction: column;
     align-items: center;
-    margin: 3rem 3rem;
+    margin: 1rem 1rem;
   }
 }
 
@@ -36,12 +43,14 @@ body:not(.homepage) {
   display: flex;
   align-items: center;
   flex: 0 0 30%;
-  max-width: 300px;
+  max-width: 150px;
   width: 100%;
-  margin-bottom: 5rem;
+  padding: 0rem 1rem;
 
-  @media only screen and (min-width: 1616px){
-    padding: 1rem 1rem;
+  @media only screen and (max-width: 768px){
+    flex-direction: column;
+    align-items: center;
+    margin: 3rem 3rem;
   }
 }
 


### PR DESCRIPTION
This PR completes the work done in https://github.com/strimzi/strimzi-kafka-operator/pull/11621 to the ADOPTERS.md file and splits also the company logos on the website to vendors and users. It also makes the logos smaller in general, to make it easier fit the website (and thus also easier to screenshot etc.)