### PR TITLE
docs(site): adds `upgrading` to deploying guide tile

### DIFF
--- a/_includes/documentation/documentation-archive-band.html
+++ b/_includes/documentation/documentation-archive-band.html
@@ -14,7 +14,7 @@
           <h5>{{oRelease.version}}</h5>
           <ul>
             {% if oRelease.overview_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/overview.html">Overview guide</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/overview.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
-            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying and Managing</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/deploying.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
+            {% if oRelease.deploying_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/deploying.html">Deploying, Managing, and Upgrading</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/deploying.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
             {% if oRelease.configuring_book %}<li><a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/configuring.html">API Reference</a> <a href="{{site.baseurl}}/docs/operators/{{oRelease.version}}/full/configuring.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>{% endif %}
           </ul>  
         {% elsif oRelease.directory_layout == "layout4" %}

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -70,7 +70,7 @@
         <summary>View guides in alternative format</summary>
         <ul>
           <li><a href="/docs/operators/latest/full/overview.html" target="_blank">Overview</a> <i class="fas fa-external-link-alt external"></i></li>
-          <li><a href="/docs/operators/latest/full/deploying.html" target="_blank">Deploying and Upgrading</a> <i class="fas fa-external-link-alt external"></i></li>
+          <li><a href="/docs/operators/latest/full/deploying.html" target="_blank">Deploying, Managing, and Upgrading</a> <i class="fas fa-external-link-alt external"></i></li>
           <li><a href="/docs/operators/latest/full/configuring.html" target="_blank">API Reference</a> <i class="fas fa-external-link-alt external"></i></li>
         </ul>
       </details>
@@ -114,8 +114,8 @@
           <i class="fas fa-arrow-right arrow"></i>
         </a>
         <a href="{{site.baseurl}}/docs/operators/in-development/deploying.html" class="tile">
-          <h6>Deploying and Managing</h6>
-          <p>Step-by-step guide to deploying and configuring Strimzi</p>
+          <h6>Deploying, Managing, and Upgrading</h6>
+          <p>Step-by-step guide to deploying, configuring, and upgrading Strimzi</p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
         <a href="{{site.baseurl}}/docs/operators/in-development/configuring.html" class="tile">
@@ -139,7 +139,7 @@
           <summary></i>View guides in alternative format</i></summary>
           <ul>
             <li><a href="/docs/operators/in-development/full/overview.html" target="_blank">Overview</a> <i class="fas fa-external-link-alt external"></i></li>
-            <li><a href="/docs/operators/in-development/full/deploying.html" target="_blank">Deploying and Upgrading</a> <i class="fas fa-external-link-alt external"></i></li>
+            <li><a href="/docs/operators/in-development/full/deploying.html" target="_blank">Deploying, Managing, and Upgrading</a> <i class="fas fa-external-link-alt external"></i></li>
             <li><a href="/docs/operators/in-development/full/configuring.html" target="_blank">API Reference</a> <i class="fas fa-external-link-alt external"></i></li>
             <li><a href="/docs/bridge/in-development/full/bridge.html" target="_blank">Kafka Bridge documentation</a> <i class="fas fa-external-link-alt external"></i></li>
           </ul>


### PR DESCRIPTION
**Documentation page on website**

Adds `upgrading` to Deploying guide tile to make it more obvious where to find info on upgrading

* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
