### PR TITLE
docs(glossary): reset internal links

### DIFF
--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -156,7 +156,7 @@
       <div class="grid-container">
         <a href="{{site.baseurl}}/glossary/guide/" class="tile">
           <h6>Glossary</h6>
-          <p>A quick reference to the latest Strimzi terminology, including Kafka custom resources, Kubernetes operators, and core components.</p>
+          <p>A quick reference to the latest Strimzi terminology, including Kafka custom resources, Kubernetes operators, and core components</p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
         <a href="{{site.baseurl}}/contributing/guide/" class="tile">

--- a/glossary/guide/index.md
+++ b/glossary/guide/index.md
@@ -4,3 +4,28 @@ layout: default
 ---
 
 {% include_relative glossary.html %}
+
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+  
+  var docsPath = "{{ '/docs/operators/latest/' | relative_url }}";
+  var allLinks = document.querySelectorAll('a');
+
+  allLinks.forEach(function(link) {
+    var originalHref = link.getAttribute('href');
+
+    // Internal link check
+    if (originalHref && 
+        originalHref.includes('.html') && 
+        !originalHref.startsWith('http')) {
+      
+      // Removes the .html
+      var newHref = originalHref.replace('./', '').replace('.html', '');
+      
+      // adds latest path
+      link.setAttribute('href', docsPath + newHref);
+    }
+  });
+
+});
+</script>


### PR DESCRIPTION
**web site**

Documentation page
Reset of glossary links

* [ ] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
