### PR TITLE
Added Strimzi ecosystem session at KubeCon NA 2025 maintainer track

### DIFF
--- a/_data/presentations.yaml
+++ b/_data/presentations.yaml
@@ -22,6 +22,11 @@
 
 years:
   2025:
+    - title: "Beyond the Operators: The Full Strimzi Ecosystem for Kafka on Kubernetes"
+      date: "2025-11-11"
+      event: "KubeCon NA — Maintainer Track"
+      recording_url: "https://www.youtube.com/watch?v=mYt9C0YQxDY"
+
     - title: "StrimziCon 2025 — session recordings"
       date: "2025-06-04"
       event: "StrimziCon 2025"


### PR DESCRIPTION
This PR adds the session "Beyond the Operators: The Full Strimzi Ecosystem for Kafka on Kubernetes" at KubeCon NA 2025.
