### PR TITLE
Removed Neeraj Laad from StrimziCon 2026 program committee

### DIFF
--- a/_posts/2026-02-18-strimzicon2026-announcement.md
+++ b/_posts/2026-02-18-strimzicon2026-announcement.md
@@ -50,7 +50,6 @@ We'll have representatives from IBM, Ericsson, Reddit, Red Hat, and Elation Heal
 * [Jakub Scholz](https://www.linkedin.com/in/scholzj/) (Principal Engineer @Cloudera)
 * [Mickael Maison](https://www.linkedin.com/in/mickaelmaison/) (Senior Principal Software Engineer @IBM)
 * [Shubham Rawat](https://www.linkedin.com/in/shubhamrwt/) (Senior Software Engineer @IBM)
-* [Neeraj Laad](https://uk.linkedin.com/in/neeraj-laad) (Software Architect @IBM)
 
 The committee members will leverage their experience and knowledge on the project as users and contributors in order to select the best proposals and build an awesome agenda.
 


### PR DESCRIPTION
This PR remove Neeraj Laad as program commitee member from the blog post about StrimziCon 2026 because unfortunately he wasn't able to join the review process anymore.