### PR TITLE
Added blog post with StrimziCon 2026 schedule

### DIFF
--- a/_posts/2026-04-17-strimzicon2026-schedule.md
+++ b/_posts/2026-04-17-strimzicon2026-schedule.md
@@ -1,0 +1,35 @@
+---
+layout: post
+title:  "StrimziCon 2026: Schedule announced!"
+date: 2026-04-17
+author: paolo_patierno
+---
+
+We are very pleased to announce the speakers and sessions for the third edition of StrimziCon!
+The interest from the community was really high and we received a lot of awesome proposals.
+The program committee found it really tough to choose among them in order to build an amazing agenda.
+
+<!--more-->
+
+![StrimziCon 2026 Banner](/assets/images/posts/2026-02-18-strimzicon2026-banner.png)
+
+### Awesome sessions ... join StrimziCon! 
+
+The conference will take place on <b>Wednesday, June 3rd, 2026</b> (afternoon CEST).
+It will start with a keynote from Kate Stanley (IBM, Strimzi maintainer) and Paolo Patierno (IBM, Strimzi maintainer).
+The keynote will be followed by almost 4 hours of breakout sessions covering several topics from core Strimzi features, to use cases, operations and integrations.
+
+| Time (CEST) | Session |
+|:---:|:---:|
+| 14:00 - 14:20 | Keynote (Kate Stanley & Paolo Patierno @ IBM) |
+| 14:25 - 14:55 | Beyond the Install: Take full ownership of your Strimzi cluster (Jakub Scholz @ Cloudera) |
+| 15:00 - 15:30 | Who Are You? Configuring Kafka Authentication in Strimzi from TLS to Custom Principals (Daniel Mulder @ Axual) |
+| 15:35 - 16:05 | Swapping the Engine Mid-Flight: How We Moved Reddit’s Petabyte Scale Kafka Fleet to Kubernetes (Sky Kistler @ Reddit) |
+| 16:10 - 16:40 | Disaster Recovery in action with Kafka and Strimzi (Mickael Maison @ IBM) |
+| 16:45 - 17:15 | From Running to Operating: Real-World Strimzi in Production (Rajith Attapattu @ Randoli) |
+| 17:20 - 17:50 | Building Strimzi MCP Server for Kubernetes: Democratizing Platform Expertise Through LLMs (David Kornel, Jakub Stejskal @ IBM) |
+| 17:50 - 18:00 | Closing (Kate Stanley & Paolo Patierno @ IBM) |
+
+You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-virtual-2026/) as part of the CNCF events.
+
+Looking forward to seeing you at the conference and don't forget to [register](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-virtual-2026/). It's free!

--- a/_posts/2026-04-17-strimzicon2026-schedule.md
+++ b/_posts/2026-04-17-strimzicon2026-schedule.md
@@ -30,6 +30,6 @@ The keynote is followed by almost 4 hours of breakout sessions with topics cover
 | 17:20 - 17:50 | Building Strimzi MCP Server for Kubernetes: Democratizing Platform Expertise Through LLMs (David Kornel, Jakub Stejskal @ IBM) |
 | 17:50 - 18:00 | Closing (Kate Stanley & Paolo Patierno @ IBM) |
 
-You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-virtual-2026/) as part of the CNCF events.
+For more details about speakers and sessions, see the [CNCF event page](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-virtual-2026/).
 
 We look forward to seeing you at the conference. [Register here](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-virtual-2026/). It's free!

--- a/_posts/2026-04-17-strimzicon2026-schedule.md
+++ b/_posts/2026-04-17-strimzicon2026-schedule.md
@@ -15,9 +15,9 @@ The program committee found it really tough to choose among them in order to bui
 
 ### Awesome sessions ... join StrimziCon! 
 
-The conference will take place on <b>Wednesday, June 3rd, 2026</b> (afternoon CEST).
-It will start with a keynote from Kate Stanley (IBM, Strimzi maintainer) and Paolo Patierno (IBM, Strimzi maintainer).
-The keynote will be followed by almost 4 hours of breakout sessions covering several topics from core Strimzi features, to use cases, operations and integrations.
+The conference will take place on **Wednesday, June 3rd, 2026** (afternoon CEST).
+The event opens with a keynote from Kate Stanley and Paolo Patierno (IBM, Strimzi maintainers).
+The keynote is followed by almost 4 hours of breakout sessions with topics covering core Strimzi features, use cases, operations, and integrations.
 
 | Time (CEST) | Session |
 |:---:|:---:|
@@ -32,4 +32,4 @@ The keynote will be followed by almost 4 hours of breakout sessions covering sev
 
 You can find more details about speakers and sessions on the official [page](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-virtual-2026/) as part of the CNCF events.
 
-Looking forward to seeing you at the conference and don't forget to [register](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-virtual-2026/). It's free!
+We look forward to seeing you at the conference. [Register here](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-strimzicon-virtual-2026/). It's free!


### PR DESCRIPTION
This PR adds a blog post with the schedule for StrimziCon 2026.