### PR TITLE
Update LF copyright footer

### DIFF
--- a/_includes/project-footer.html
+++ b/_includes/project-footer.html
@@ -22,12 +22,9 @@
   <div class="grid-wrapper">
     <div class="width-12-12 width-12-12-m justify-self-center align-self-center">
       <br />
-      <p class="text-centered copyright-strimzi">
-        &copy; Strimzi Authors {{ 'now' | date: "%Y" }} | Documentation distributed under <a href="https://creativecommons.org/licenses/by/4.0">CC-BY-4.0</a>
-      </p>
-      <br />
       <p class="text-centered copyright-cncf">
-        &copy; {{ 'now' | date: "%Y" }} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a> page.
+        Copyright &copy; Strimzi a Series of LF Projects, LLC<br />
+        For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/">lfprojects.org/policies/</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This PR resolves #573 and updates the website copyright footer as requested and as described in https://github.com/cncf/foundation/blob/main/policies-guidance/website-guidelines.md