### PR TITLE
docs(docs): site updates for new bridge name

### DIFF
--- a/_includes/documentation/documentation-archive-band.html
+++ b/_includes/documentation/documentation-archive-band.html
@@ -57,7 +57,7 @@
       {% endfor %}
     </div>
     <div class="width-6-12 width-12-12-m">
-      <h4>Strimzi Kafka Bridge</h4>
+      <h4>Strimzi HTTP Bridge</h4>
       {% for bRelease in site.data.releases.bridge %}
           <ul>
             <li><a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}">{{bRelease.version}}</a> <a href="{{site.baseurl}}/docs/bridge/{{bRelease.version}}/full.html" title="Full documentation (New Window)" target="_blank"><i class="fas fa-external-link-alt"></i></a></li>

--- a/_includes/documentation/documentation-version-band.html
+++ b/_includes/documentation/documentation-version-band.html
@@ -19,7 +19,8 @@
         
       </ul>
       <p>
-        Additionally, Strimzi's <b>Kafka Bridge</b> provides a RESTful interface for producing and consuming messages, making it easier to integrate Kafka with your applications.
+        Additionally, Strimzi's <b>HTTP Bridge</b> provides a RESTful interface for producing and consuming messages, making it easier to integrate Kafka with your applications.
+        In earlier Strimzi versions, this component was referred to as the Kafka Bridge.
       </p>
       <p>
         Explore the guides below, or jump directly to the <a href="{{site.baseurl}}/docs/operators/latest/overview.html">Overview</a> for a comprehensive introduction to Strimzi operators and features.
@@ -31,7 +32,7 @@
     <!-- Latest Strimzi docs -->
     <div class="width-12-12">
       <h2>Latest Strimzi documentation</h2>
-      <p>Documentation for Strimzi {{site.data.releases.operator[0].version}}, which supports Kafka Bridge {{site.data.releases.bridge[0].version}}.</p>
+      <p>Documentation for Strimzi {{site.data.releases.operator[0].version}}, which supports HTTP Bridge {{site.data.releases.bridge[0].version}}.</p>
 
       <div class="grid-container">
         <a href="{{site.baseurl}}/docs/operators/latest/overview.html" class="tile">
@@ -60,8 +61,8 @@
           <i class="fas fa-arrow-right arrow"></i>
         </a>
         <a href="{{site.baseurl}}/docs/bridge/latest/" class="tile">
-          <h6>Using the Kafka Bridge</h6>
-          <p>Learn how to produce and consume messages through the Kafka Bridge</p>
+          <h6>Using the HTTP Bridge</h6>
+          <p>Learn how to produce and consume messages through the HTTP Bridge</p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
       </div>
@@ -81,12 +82,12 @@
 
     <!-- Latest Bridge docs -->
     <div class="width-12-12">
-      <h2>Latest Kafka Bridge documentation</h2>
-      <p>Documentation for Kafka Bridge {{site.data.releases.bridge[0].version}}.</p>
+      <h2>Latest HTTP Bridge documentation</h2>
+      <p>Documentation for HTTP Bridge {{site.data.releases.bridge[0].version}}.</p>
       <div class="grid-container">
         <a href="{{site.baseurl}}/docs/bridge/latest/" class="tile">
-          <h6>Using the Kafka Bridge</h6>
-          <p>Learn how to produce and consume messages through the Kafka Bridge</p>
+          <h6>Using the HTTP Bridge</h6>
+          <p>Learn how to produce and consume messages through the HTTP Bridge</p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
       </div>
@@ -94,7 +95,7 @@
         <details class="full-docs">
           <summary>View guides in alternative format</summary>
           <ul>
-            <li><a href="/docs/bridge/latest/full.html" target="_blank">Kafka Bridge documentation</a> <i class="fas fa-external-link-alt external"></i></li>
+            <li><a href="/docs/bridge/latest/full.html" target="_blank">HTTP Bridge documentation</a> <i class="fas fa-external-link-alt external"></i></li>
           </ul>
         </details>
       </p>
@@ -129,8 +130,8 @@
           <i class="fas fa-arrow-right arrow"></i>
         </a>
         <a href="{{site.baseurl}}/docs/bridge/in-development/" class="tile">
-          <h6>Using the Kafka Bridge</h6>
-          <p>Learn how to produce and consume messages through the Kafka Bridge</p>
+          <h6>Using the HTTP Bridge</h6>
+          <p>Learn how to produce and consume messages through the HTTP Bridge</p>
           <i class="fas fa-arrow-right arrow"></i>
         </a>
       </div>
@@ -141,7 +142,7 @@
             <li><a href="/docs/operators/in-development/full/overview.html" target="_blank">Overview</a> <i class="fas fa-external-link-alt external"></i></li>
             <li><a href="/docs/operators/in-development/full/deploying.html" target="_blank">Deploying, Managing, and Upgrading</a> <i class="fas fa-external-link-alt external"></i></li>
             <li><a href="/docs/operators/in-development/full/configuring.html" target="_blank">API Reference</a> <i class="fas fa-external-link-alt external"></i></li>
-            <li><a href="/docs/bridge/in-development/full/bridge.html" target="_blank">Kafka Bridge documentation</a> <i class="fas fa-external-link-alt external"></i></li>
+            <li><a href="/docs/bridge/in-development/full/bridge.html" target="_blank">HTTP Bridge documentation</a> <i class="fas fa-external-link-alt external"></i></li>
           </ul>
         </details>
       </p>

--- a/_includes/downloads/downloads-release-band.html
+++ b/_includes/downloads/downloads-release-band.html
@@ -74,7 +74,7 @@
           <tr>
             <th colspan="3">
               <div class="version-name">
-                Strimzi Kafka Bridge {{bRelease}}<span class="release-date"></span>
+                Strimzi HTTP Bridge {{bRelease}}<span class="release-date"></span>
               </div>
             </th>
           </tr>

--- a/_includes/downloads/supported-versions-band.html
+++ b/_includes/downloads/supported-versions-band.html
@@ -14,7 +14,7 @@
           </th>
           <th>
             <div class="supported-component">
-              Strimzi Kafka Bridge<span class="release-date"></span>
+              Strimzi HTTP Bridge<span class="release-date"></span>
             </div>
           </th>
           <th>

--- a/_includes/grow-your-role/grow-your-role.html
+++ b/_includes/grow-your-role/grow-your-role.html
@@ -29,7 +29,7 @@
          Become a component owner
       </h3>
       <p>
-        As you gain experience, you might naturally focus on a specific area — for example, documentation, CI tooling, or a particular component like the Kafka Bridge. 
+        As you gain experience, you might naturally focus on a specific area — for example, documentation, CI tooling, or a particular component like the HTTP Bridge. 
         You could become a component owner, taking shared responsibility for an area of the project.
       </p>
       <p>

--- a/_includes/homepage/homepage-download-announcement-band.html
+++ b/_includes/homepage/homepage-download-announcement-band.html
@@ -2,10 +2,10 @@
   <div class="grid-wrapper ctas">
     <div class="width-12-12">
       <h2>Version {{site.data.releases.operator[0].version}} download is available!</h2>
-      <h5>Download the latest Strimzi releases from <a href="{{ site.github_url }}" target="_blank">GitHub</a>. Use the Kafka operators to deploy and configure an Apache Kafka cluster on Kubernetes. The <a href="{{site.baseurl}}/docs/latest/#kafka-bridge-concepts-str">Kafka Bridge</a> provides a RESTful interface for your HTTP clients.</h5>
+      <h5>Download the latest Strimzi releases from <a href="{{ site.github_url }}" target="_blank">GitHub</a>. Use the Kafka operators to deploy and configure an Apache Kafka cluster on Kubernetes. The <a href="{{site.baseurl}}/docs/bridge/in-development/">HTTP Bridge</a> provides a RESTful interface for your HTTP clients.</h5>
       <div class="ctas">
           <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{{site.data.releases.operator[0].version}}" class="button-cta">Download Strimzi Kafka Operators</a>
-          <a href="https://github.com/strimzi/strimzi-kafka-bridge/releases/tag/{{site.data.releases.bridge[0].version}}" class="button-cta">Download Strimzi Kafka Bridge</a>
+          <a href="https://github.com/strimzi/strimzi-kafka-bridge/releases/tag/{{site.data.releases.bridge[0].version}}" class="button-cta">Download Strimzi HTTP Bridge</a>
       </div>
     </div>
   </div>

--- a/_includes/homepage/homepage-download-announcement-band.html
+++ b/_includes/homepage/homepage-download-announcement-band.html
@@ -2,7 +2,7 @@
   <div class="grid-wrapper ctas">
     <div class="width-12-12">
       <h2>Version {{site.data.releases.operator[0].version}} download is available!</h2>
-      <h5>Download the latest Strimzi releases from <a href="{{ site.github_url }}" target="_blank">GitHub</a>. Use the Kafka operators to deploy and configure an Apache Kafka cluster on Kubernetes. The <a href="{{site.baseurl}}/docs/bridge/in-development/">HTTP Bridge</a> provides a RESTful interface for your HTTP clients.</h5>
+      <h5>Download the latest Strimzi releases from <a href="{{ site.github_url }}" target="_blank">GitHub</a>. Use the Kafka operators to deploy and configure an Apache Kafka cluster on Kubernetes. The <a href="{{site.baseurl}}/docs/bridge/latest/">HTTP Bridge</a> provides a RESTful interface for your HTTP clients.</h5>
       <div class="ctas">
           <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{{site.data.releases.operator[0].version}}" class="button-cta">Download Strimzi Kafka Operators</a>
           <a href="https://github.com/strimzi/strimzi-kafka-bridge/releases/tag/{{site.data.releases.bridge[0].version}}" class="button-cta">Download Strimzi HTTP Bridge</a>

--- a/_includes/join-us/join-us-contribute-to-strimzi-band.html
+++ b/_includes/join-us/join-us-contribute-to-strimzi-band.html
@@ -9,7 +9,7 @@
 
       <p>
         Strimzi is more than just the Kafka operators. 
-        Check out our <a href="https://github.com/orgs/strimzi/repositories" target="_blank" rel="noopener noreferrer">sub-projects and tools</a> — including the Kafka Bridge and Drain Cleaner — to find what interests you most.
+        Check out our <a href="https://github.com/orgs/strimzi/repositories" target="_blank" rel="noopener noreferrer">sub-projects and tools</a> — including the HTTP Bridge and Drain Cleaner — to find what interests you most.
       </p>
 
       <p>

--- a/_includes/releases-archives-band.html
+++ b/_includes/releases-archives-band.html
@@ -16,7 +16,7 @@
       {% endfor %}
     </div>
     <div class="width-6-12 width-12-12-m">
-      <h4>Strimzi Kafka Bridge</h4>
+      <h4>Strimzi HTTP Bridge</h4>
       {% for bRelease in site.data.releases.bridge %}
           <ul>
             <li><a href="https://github.com/strimzi/strimzi-kafka-bridge/releases/tag/{{bRelease.version}}">{{bRelease.version}}</a></li>

--- a/_sass/includes/toc.scss
+++ b/_sass/includes/toc.scss
@@ -444,3 +444,7 @@ input:checked + .slider:before {
   height: 45px;
 }
 
+/* Hide duplicate title link in older Bridge guides */
+.doc-content h1#api_reference-book {
+  display: none;
+}

--- a/docs/bridge/0.12.0/index.md
+++ b/docs/bridge/0.12.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.12.0)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.12.0)</h1>
-
 {% include_relative 0.12.0.html %}

--- a/docs/bridge/0.12.1/index.md
+++ b/docs/bridge/0.12.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.12.1)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.12.1)</h1>
-
 {% include_relative 0.12.1.html %}

--- a/docs/bridge/0.12.2/index.md
+++ b/docs/bridge/0.12.2/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.12.2)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.12.2)</h1>
-
 {% include_relative 0.12.2.html %}

--- a/docs/bridge/0.13.0/index.md
+++ b/docs/bridge/0.13.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.13.0)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.13.0)</h1>
-
 {% include_relative 0.13.0.html %}

--- a/docs/bridge/0.14.0/index.md
+++ b/docs/bridge/0.14.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.14.0)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.14.0)</h1>
-
 {% include_relative 0.14.0.html %}

--- a/docs/bridge/0.15.0/index.md
+++ b/docs/bridge/0.15.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.15.0)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.15.0)</h1>
-
 {% include_relative 0.15.0.html %}

--- a/docs/bridge/0.15.1/index.md
+++ b/docs/bridge/0.15.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.15.1)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.15.1)</h1>
-
 {% include_relative 0.15.1.html %}

--- a/docs/bridge/0.15.2/index.md
+++ b/docs/bridge/0.15.2/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.15.2)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.15.2)</h1>
-
 {% include_relative 0.15.2.html %}

--- a/docs/bridge/0.16.0/index.md
+++ b/docs/bridge/0.16.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.16.0)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.16.0)</h1>
-
 {% include_relative 0.16.0.html %}

--- a/docs/bridge/0.17.0/index.md
+++ b/docs/bridge/0.17.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.17.0)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.17.0)</h1>
-
 {% include_relative 0.17.0.html %}

--- a/docs/bridge/0.18.0/index.md
+++ b/docs/bridge/0.18.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.18.0)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.18.0)</h1>
-
 {% include_relative 0.18.0.html %}

--- a/docs/bridge/0.19.0/index.md
+++ b/docs/bridge/0.19.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.19.0)
 layout: default
 ---
 
-<h1>Strimzi Kafka Bridge Documentation (0.19.0)</h1>
-
 {% include_relative 0.19.0.html %}

--- a/docs/bridge/0.20.0/index.md
+++ b/docs/bridge/0.20.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.20.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.20.0)</h1>
-
 {% include_relative 0.20.0.html %}

--- a/docs/bridge/0.20.1/index.md
+++ b/docs/bridge/0.20.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.20.1)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.20.1)</h1>
-
 {% include_relative 0.20.1.html %}

--- a/docs/bridge/0.20.2/index.md
+++ b/docs/bridge/0.20.2/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.20.2)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.20.2)</h1>
-
 {% include_relative 0.20.2.html %}

--- a/docs/bridge/0.20.3/index.md
+++ b/docs/bridge/0.20.3/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.20.3)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.20.3)</h1>
-
 {% include_relative 0.20.3.html %}

--- a/docs/bridge/0.21.0/index.md
+++ b/docs/bridge/0.21.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.21.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.21.0)</h1>
-
 {% include_relative 0.21.0.html %}

--- a/docs/bridge/0.21.1/index.md
+++ b/docs/bridge/0.21.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.21.1)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.21.1)</h1>
-
 {% include_relative 0.21.1.html %}

--- a/docs/bridge/0.21.2/index.md
+++ b/docs/bridge/0.21.2/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.21.2)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.21.2)</h1>
-
 {% include_relative 0.21.2.html %}

--- a/docs/bridge/0.21.3/index.md
+++ b/docs/bridge/0.21.3/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.21.3)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.21.3)</h1>
-
 {% include_relative 0.21.3.html %}

--- a/docs/bridge/0.21.4/index.md
+++ b/docs/bridge/0.21.4/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.21.4)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.21.4)</h1>
-
 {% include_relative 0.21.4.html %}

--- a/docs/bridge/0.21.5/index.md
+++ b/docs/bridge/0.21.5/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.21.5)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.21.5)</h1>
-
 {% include_relative 0.21.5.html %}

--- a/docs/bridge/0.21.6/index.md
+++ b/docs/bridge/0.21.6/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.21.6)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.21.6)</h1>
-
 {% include_relative 0.21.6.html %}

--- a/docs/bridge/0.22.0/index.md
+++ b/docs/bridge/0.22.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.22.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.22.0)</h1>
-
 {% include_relative 0.22.0.html %}

--- a/docs/bridge/0.22.1/index.md
+++ b/docs/bridge/0.22.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.22.1)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.22.1)</h1>
-
 {% include_relative 0.22.1.html %}

--- a/docs/bridge/0.22.2/index.md
+++ b/docs/bridge/0.22.2/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.22.2)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.22.2)</h1>
-
 {% include_relative 0.22.2.html %}

--- a/docs/bridge/0.22.3/index.md
+++ b/docs/bridge/0.22.3/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.22.3)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.22.3)</h1>
-
 {% include_relative 0.22.3.html %}

--- a/docs/bridge/0.23.0/index.md
+++ b/docs/bridge/0.23.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.23.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.23.0)</h1>
-
 {% include_relative 0.23.0.html %}

--- a/docs/bridge/0.23.1/index.md
+++ b/docs/bridge/0.23.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.23.1)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.23.1)</h1>
-
 {% include_relative 0.23.1.html %}

--- a/docs/bridge/0.24.0/index.md
+++ b/docs/bridge/0.24.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.24.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.24.0)</h1>
-
 {% include_relative 0.24.0.html %}

--- a/docs/bridge/0.25.0/index.md
+++ b/docs/bridge/0.25.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.25.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.25.0)</h1>
-
 {% include_relative 0.25.0.html %}

--- a/docs/bridge/0.26.0/index.md
+++ b/docs/bridge/0.26.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.26.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.26.0)</h1>
-
 {% include_relative 0.26.0.html %}

--- a/docs/bridge/0.26.1/index.md
+++ b/docs/bridge/0.26.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.26.1)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.26.1)</h1>
-
 {% include_relative 0.26.1.html %}

--- a/docs/bridge/0.27.0/index.md
+++ b/docs/bridge/0.27.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.27.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.27.0)</h1>
-
 {% include_relative 0.27.0.html %}

--- a/docs/bridge/0.28.0/index.md
+++ b/docs/bridge/0.28.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.28.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.28.0)</h1>
-
 {% include_relative 0.28.0.html %}

--- a/docs/bridge/0.29.0/index.md
+++ b/docs/bridge/0.29.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.29.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.29.0)</h1>
-
 {% include_relative 0.29.0.html %}

--- a/docs/bridge/0.30.0/index.md
+++ b/docs/bridge/0.30.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.30.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.30.0)</h1>
-
 {% include_relative 0.30.0.html %}

--- a/docs/bridge/0.31.0/index.md
+++ b/docs/bridge/0.31.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.31.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.31.0)</h1>
-
 {% include_relative 0.31.0.html %}

--- a/docs/bridge/0.31.1/index.md
+++ b/docs/bridge/0.31.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.31.1)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.31.1)</h1>
-
 {% include_relative 0.31.1.html %}

--- a/docs/bridge/0.31.2/index.md
+++ b/docs/bridge/0.31.2/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.31.2)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.31.2)</h1>
-
 {% include_relative 0.31.2.html %}

--- a/docs/bridge/0.32.0/index.md
+++ b/docs/bridge/0.32.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.32.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.32.0)</h1>
-
 {% include_relative 0.32.0.html %}

--- a/docs/bridge/0.33.0/index.md
+++ b/docs/bridge/0.33.0/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.33.0)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.33.0)</h1>
-
 {% include_relative 0.33.0.html %}

--- a/docs/bridge/0.33.1/index.md
+++ b/docs/bridge/0.33.1/index.md
@@ -3,6 +3,4 @@ title: Strimzi Kafka Bridge Documentation (0.33.1)
 layout: default
 ---
 
-<h1 >Strimzi Kafka Bridge Documentation (0.33.1)</h1>
-
 {% include_relative 0.33.1.html %}

--- a/docs/bridge/1.0.0/index.md
+++ b/docs/bridge/1.0.0/index.md
@@ -1,8 +1,6 @@
 ---
-title: Strimzi Kafka Bridge Documentation (1.0.0)
+title: Strimzi HTTP Bridge Documentation (1.0.0)
 layout: default
 ---
-
-<h1 >Strimzi Kafka Bridge Documentation (1.0.0)</h1>
 
 {% include_relative 1.0.0.html %}

--- a/docs/bridge/in-development/index.md
+++ b/docs/bridge/in-development/index.md
@@ -1,5 +1,5 @@
 ---
-title: Strimzi Kafka Bridge Documentation (In Development)
+title: Strimzi HTTP Bridge Documentation (In Development)
 layout: default
 ---
 

--- a/docs/bridge/latest/index.md
+++ b/docs/bridge/latest/index.md
@@ -1,5 +1,5 @@
 ---
-title: Strimzi Kafka Bridge Documentation (!LATEST_BRIDGE_VERSION!)
+title: Strimzi HTTP Bridge Documentation (!LATEST_BRIDGE_VERSION!)
 layout: default
 ---
 


### PR DESCRIPTION
**Bridge name change on site**

Few updates related to HTTP Bridge name change

- Renaming of HTTP Bridge + note on name change on documentation page
- Bridge docs link fix from homepage
- Fixed titles issue from documentation archive links:  repeating 2 or 3 main titles

_Select the type of your PR_

* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other
