### PR TITLE
Fix incorrect property paths in KafkaMirrorMaker2 v1 API migration docs

### DIFF
--- a/docs/operators/0.49.0/deploying-book.html
+++ b/docs/operators/0.49.0/deploying-book.html
@@ -35343,16 +35343,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.49.0/full/deploying.html
+++ b/docs/operators/0.49.0/full/deploying.html
@@ -35785,16 +35785,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.49.1/deploying-book.html
+++ b/docs/operators/0.49.1/deploying-book.html
@@ -32882,16 +32882,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.49.1/full/deploying.html
+++ b/docs/operators/0.49.1/full/deploying.html
@@ -33324,16 +33324,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.50.0/deploying-book.html
+++ b/docs/operators/0.50.0/deploying-book.html
@@ -33187,16 +33187,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.50.0/full/deploying.html
+++ b/docs/operators/0.50.0/full/deploying.html
@@ -33629,16 +33629,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.50.1/deploying-book.html
+++ b/docs/operators/0.50.1/deploying-book.html
@@ -33187,16 +33187,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.50.1/full/deploying.html
+++ b/docs/operators/0.50.1/full/deploying.html
@@ -33629,16 +33629,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.51.0/deploying-book.html
+++ b/docs/operators/0.51.0/deploying-book.html
@@ -33971,16 +33971,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/0.51.0/full/deploying.html
+++ b/docs/operators/0.51.0/full/deploying.html
@@ -34413,16 +34413,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/1.0.0/deploying-book.html
+++ b/docs/operators/1.0.0/deploying-book.html
@@ -34047,16 +34047,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/1.0.0/full/deploying.html
+++ b/docs/operators/1.0.0/full/deploying.html
@@ -34489,16 +34489,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/latest/deploying-book.html
+++ b/docs/operators/latest/deploying-book.html
@@ -34047,16 +34047,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>

--- a/docs/operators/latest/full/deploying.html
+++ b/docs/operators/latest/full/deploying.html
@@ -34489,16 +34489,16 @@ If <code>pause: true</code> was set, it is converted to <code>state: paused</cod
 <div class="ulist">
 <ul>
 <li>
-<p><code>.spec.groupId</code>: set from <code>.spec.config.group.id</code>, or default to <code>connect-cluster</code>.</p>
+<p><code>.spec.target.groupId</code>: set from <code>.spec.clusters[].config.group.id</code> of the target cluster, or default to <code>connect-cluster</code>.</p>
 </li>
 <li>
-<p><code>.spec.configStorageTopic</code>: set from <code>.spec.config.config.storage.topic</code>, or default to <code>connect-cluster-configs</code>.</p>
+<p><code>.spec.target.configStorageTopic</code>: set from <code>.spec.clusters[].config.config.storage.topic</code> of the target cluster, or default to <code>connect-cluster-configs</code>.</p>
 </li>
 <li>
-<p><code>.spec.offsetStorageTopic</code>: set from <code>.spec.config.offset.storage.topic</code>, or default to <code>connect-cluster-offsets</code>.</p>
+<p><code>.spec.target.offsetStorageTopic</code>: set from <code>.spec.clusters[].config.offset.storage.topic</code> of the target cluster, or default to <code>connect-cluster-offsets</code>.</p>
 </li>
 <li>
-<p><code>.spec.statusStorageTopic</code>: set from <code>.spec.config.status.storage.topic</code>, or default to <code>connect-cluster-status</code>.</p>
+<p><code>.spec.target.statusStorageTopic</code>: set from <code>.spec.clusters[].config.status.storage.topic</code> of the target cluster, or default to <code>connect-cluster-status</code>.</p>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
Fixes #576

### Type of change

_Select the type of your PR_

* [x] Typo/minor fix
* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
* [ ] Other

### Description
Fixed incorrect property paths in the KafkaMirrorMaker2 v1 API migration documentation (section 30.7.4).

Error #1: Wrong Target Property Paths
Documentation incorrectly stated properties at .spec level instead of .spec.target:

Changed .spec.groupId → .spec.target.groupId
Changed .spec.configStorageTopic → .spec.target.configStorageTopic
Changed .spec.offsetStorageTopic → .spec.target.offsetStorageTopic
Changed .spec.statusStorageTopic → .spec.target.statusStorageTopic

Error #2: Incorrect Reference to .spec.config
Documentation incorrectly referenced .spec.config which does not exist in KafkaMirrorMaker2 CRD.

Before:
"set from .spec.config.group.id"
"set from .spec.config.config.storage.topic"
"set from .spec.config.offset.storage.topic"
"set from .spec.config.status.storage.topic"

After:
"set from .spec.clusters[].config.group.id of the target cluster"
"set from .spec.clusters[].config.config.storage.topic of the target cluster"
"set from .spec.clusters[].config.offset.storage.topic of the target cluster"
"set from .spec.clusters[].config.status.storage.topic of the target cluster"