### PR TITLE
Add Strimzi Drain Cleaner 1.6.0 after the release

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -2,6 +2,25 @@ apiVersion: v1
 entries:
   strimzi-drain-cleaner:
   - apiVersion: v2
+    appVersion: 1.6.0
+    created: "2026-05-05T20:04:14.167685+02:00"
+    description: Utility which helps with moving the Apache Kafka pods deployed by
+      Strimzi from Kubernetes nodes which are being drained.
+    digest: fd290303f379c9e98b5afc2e97dd1d1d8adaa9e75c04cc5f76e02f7a7f3397c6
+    home: https://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
+    maintainers:
+    - email: cncf-strimzi-maintainers@lists.cncf.io
+      name: Strimzi Project Maintainers
+      url: https://github.com/strimzi/governance
+    name: strimzi-drain-cleaner
+    sources:
+    - https://github.com/strimzi/drain-cleaner
+    type: application
+    urls:
+    - https://github.com/strimzi/drain-cleaner/releases/download/1.6.0/strimzi-drain-cleaner-helm-3-chart-1.6.0.tgz
+    version: 1.6.0
+  - apiVersion: v2
     appVersion: 1.5.0
     created: "2026-01-12T10:30:55.296434+01:00"
     description: Utility which helps with moving the Apache Kafka pods deployed by
@@ -2143,4 +2162,4 @@ entries:
     urls:
     - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
     version: 0.6.0
-generated: "2026-04-28T11:28:02.723444+02:00"
+generated: "2026-05-05T20:04:14.164972+02:00"


### PR DESCRIPTION
### Type of change

* [X] New release

### Description

This PR adds Strimzi Drain Cleaner 1.6.0 to the website's Helm chart index.yaml after the release.