### PR TITLE
Add Strimzicon 2026 redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -5,6 +5,9 @@
 /install/latest                     https://github.com/strimzi/strimzi-kafka-operator/releases/download/1.0.0/strimzi-cluster-operator-1.0.0.yaml       200
 /examples/latest/*                  https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/examples/:splat                               200
 
+# StrimziCon 2026 shortcut
+/conference                         blog/2026/04/17/strimzicon2026-schedule/                200
+
 # Redirects for old website URL structure
 /2018/:month/:date/:slug            /blog/2018/:month/:date/:slug                                                                                       301
 /2019/:month/:date/:slug            /blog/2019/:month/:date/:slug                                                                                       301

--- a/_redirects
+++ b/_redirects
@@ -6,7 +6,7 @@
 /examples/latest/*                  https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/examples/:splat                               200
 
 # StrimziCon 2026 shortcut
-/conference                         blog/2026/04/17/strimzicon2026-schedule/                200
+/conference                         /blog/2026/04/17/strimzicon2026-schedule/                200
 
 # Redirects for old website URL structure
 /2018/:month/:date/:slug            /blog/2018/:month/:date/:slug                                                                                       301


### PR DESCRIPTION
This PR adds the redirect for `stirmzi.io/conference` to the StrimziCon 2026 agenda.