### PR TITLE
Minor updates to the issue and Pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 I have:
 
 * [ ] Checked that the problem is not about the Strimzi documentation.
-  Documentation issues (those with URLs starting https://strimzi.io/docs/...) should be reported [here](https://github.com/strimzi/strimzi-kafka-operator/issues/new?title=Docs:&labels=documentation).
+  Documentation issues (those with URLs starting https://strimzi.io/documentation/...) should be reported [here](https://github.com/strimzi/strimzi-kafka-operator/issues/new?template=documentation.yaml).
 * [ ] Included the URL of the page my issue is about
 * [ ] Described what I did see and what I was expecting to see 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,15 @@
 ### Type of change
 
-_Select the type of your PR_
+_Select the type of your PR and delete the other items_
 
-* [ ] Typo/minor fix
-* [ ] New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
-* [ ] Other
+- Typo/minor fix
+- New blog post (see the [README](https://github.com/strimzi/strimzi.github.io/#blog-posts) for the process)
+- Other
+
+### Description
+
+_Please describe your pull request_
+
+### Checklist
+
+- [ ] AI assistance was used to create this PR


### PR DESCRIPTION
The website repository has its own templates. This PR slightly updates them:
* Fixes some broken links in the Issue template
* Brings the PR template to be more in-sync with the global one