### PR TITLE
Add security section with CVE entries and advisories

### DIFF
--- a/_data/cves.yaml
+++ b/_data/cves.yaml
@@ -1,0 +1,51 @@
+#-- Adding CVE entries --
+#
+# Add a new `-` item at the top of the list (newest first).
+#
+# Required fields:
+#   id:                CVE identifier (e.g. CVE-2024-12345)
+#   title:             Short description of the vulnerability
+#   severity:          One of: critical, high, medium, low
+#   published:         Date the advisory was published (YYYY-MM-DD)
+#   advisory_url:      Link to the GitHub security advisory (GHSA)
+#   affected_versions: Version range using operators (e.g. ">= 0.40.0")
+#   fixed_versions:    Comma-separated list of versions that include the fix
+#   description:       Full description of the vulnerability (use YAML block scalar `>`)
+
+- id: CVE-2026-27134
+  title: "All CAs from a custom CA chain consisting of multiple CAs are trusted for mTLS user authentication"
+  severity: high
+  published: 2026-02-19
+  advisory_url: https://github.com/strimzi/strimzi-kafka-operator/security/advisories/GHSA-2qwx-rq6j-8r6j
+  affected_versions: ">= 0.49.0"
+  fixed_versions: "0.50.1, 0.51.0"
+  description: >
+    When using a custom Cluster or Clients CA with a multistage CA chain consisting of multiple CAs,
+    Strimzi incorrectly configures the trusted certificates for mTLS authentication on internal as well
+    as user-configured listeners. All CAs from the CA chain will be trusted, allowing users authenticated
+    by any CA in the chain to connect to the Kafka cluster.
+
+- id: CVE-2026-27133
+  title: "All CAs from CA chain will be trusted in Kafka Connect and Kafka MirrorMaker 2 target clusters"
+  severity: medium
+  published: 2026-02-19
+  advisory_url: https://github.com/strimzi/strimzi-kafka-operator/security/advisories/GHSA-6x85-j2f7-4xc5
+  affected_versions: ">= 0.47.0"
+  fixed_versions: "0.50.1, 0.51.0"
+  description: >
+    When a chain consisting of multiple CA certificates is used in the trusted certificates configuration
+    of a Kafka Connect operand or of the target cluster in the Kafka MirrorMaker 2 operand, all of the
+    certificates that are part of the CA chain will be trusted instead of only the leaf CA certificate.
+
+- id: CVE-2025-66623
+  title: "Unrestricted access to all Secrets in the same Kubernetes namespace from Kafka Connect and MirrorMaker 2 operands"
+  severity: high
+  published: 2025-12-05
+  advisory_url: https://github.com/strimzi/strimzi-kafka-operator/security/advisories/GHSA-xrhh-hx36-485q
+  affected_versions: ">= 0.47.0"
+  fixed_versions: "0.49.1"
+  description: >
+    In some situations, Strimzi creates an incorrect Kubernetes Role which grants the Apache Kafka Connect
+    and Apache Kafka MirrorMaker 2 operands GET access to all Kubernetes Secrets that exist in the given
+    Kubernetes namespace. This occurs when external listeners with TLS are configured together with Kafka
+    Connect or MirrorMaker 2 with the externalConfiguration option referencing a Secret.

--- a/_includes/downloads/downloads-release-band.html
+++ b/_includes/downloads/downloads-release-band.html
@@ -101,6 +101,7 @@
       <p>Full list of changes can be found under the <a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{{site.data.releases.operator[0].version}}">{{site.data.releases.operator[0].version}} release</a>.</p>
       <p><strong>Upgrading from Strimzi {{site.data.releases.operator[1].version}}? See the <a href="{{site.baseurl}}/documentation/">documentation</a> for upgrade instructions.</strong></p>
       <p>The container images are available under the <a href="https://quay.io/organization/strimzi">Strimzi organization</a> in the Quay.io container registry.</p>
+      <p>For known security vulnerabilities and CVEs, see the <a href="{{site.baseurl}}/security/">security advisories</a> page.</p>
     </div>
   </div>
 </div>

--- a/_includes/resources/resources-options.html
+++ b/_includes/resources/resources-options.html
@@ -60,6 +60,29 @@
 
       <hr class="section-divider">
 
+      <!-- Security -->
+      <h3 style="display: flex; align-items: center; gap: 0.5em;">
+        <img src="/assets/images/community/community_icon_submitbugs.svg" alt="" aria-hidden="true" style="height: 1.4em;">
+        Security
+      </h3>
+      <div class="grid-container">
+
+        <a class="tile" href="{{site.baseurl}}/security/">
+          <h6>Security advisories</h6>
+          <p>Known CVEs, affected versions, and fixes for Strimzi components</p>
+          <i class="fas fa-arrow-right arrow"></i>
+        </a>
+
+        <a class="tile" href="https://github.com/strimzi/strimzi-kafka-operator/security/policy" target="_blank" rel="noopener noreferrer">
+          <h6>Report a vulnerability</h6>
+          <p>Find out how to responsibly disclose a security issue to the Strimzi team</p>
+          <i class="fas fa-arrow-right arrow"></i>
+        </a>
+
+      </div>
+
+      <hr class="section-divider">
+
       <!-- Asking questions -->
       <h3 id="ask-the-community" style="display: flex; align-items: center; gap: 0.5em;">
         <img src="/assets/images/community/community_icon_question.svg" alt="" aria-hidden="true" style="height: 1.4em;">

--- a/_includes/security/security-cve-list.html
+++ b/_includes/security/security-cve-list.html
@@ -1,0 +1,45 @@
+<section class="component-slim security-cve-band">
+  <div class="grid-wrapper">
+    <div class="width-12-12">
+
+      <p>
+        This page lists all publicly disclosed security vulnerabilities (CVEs) affecting Strimzi components.
+        To report a new vulnerability, please follow the
+        <a href="https://github.com/strimzi/strimzi-kafka-operator/security/policy" target="_blank" rel="noopener noreferrer">security policy</a>.
+      </p>
+
+      <hr class="section-divider">
+
+      {% for cve in site.data.cves %}
+      <div id="{{ cve.id }}">
+        <h3>
+          <a href="#{{ cve.id }}">{{ cve.id }}</a>
+          <span class="pill pill-severity-{{ cve.severity }}">{{ cve.severity | capitalize }}</span>
+        </h3>
+        <p class="title">{{ cve.title }}</p>
+        <p>{{ cve.description }}</p>
+        <table class="cve-details-table">
+          <tr>
+            <th>Affected versions</th>
+            <td>{{ cve.affected_versions }}</td>
+          </tr>
+          <tr>
+            <th>Fixed versions</th>
+            <td>{{ cve.fixed_versions }}</td>
+          </tr>
+          <tr>
+            <th>Issue announced</th>
+            <td>{{ cve.published | date: "%d %B %Y" }}</td>
+          </tr>
+          <tr>
+            <th>Advisory</th>
+            <td><a href="{{ cve.advisory_url }}" target="_blank" rel="noopener noreferrer">{{ cve.advisory_url }}</a></td>
+          </tr>
+        </table>
+      </div>
+      <hr class="section-divider">
+      {% endfor %}
+
+    </div>
+  </div>
+</section>

--- a/_includes/security/security-title-band.html
+++ b/_includes/security/security-title-band.html
@@ -1,0 +1,10 @@
+<div class="secondary-page-title-band">
+  <div class="pattern-wrapper-light">
+    <div class="component-slim grid-wrapper">
+      <div class="width-12-12">
+        <h1>Security</h1>
+        <h3>Known CVEs, affected versions, and fixes for Strimzi components</h3>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_layouts/security.html
+++ b/_layouts/security.html
@@ -1,0 +1,6 @@
+---
+layout: base
+---
+
+{% include security/security-title-band.html %}
+{% include security/security-cve-list.html %}

--- a/_sass/strimzi.scss
+++ b/_sass/strimzi.scss
@@ -741,6 +741,40 @@ blockquote::after {
 .pill-event{background:#f2f0ff;color:#3b2f5c}
 .pill-na{background:#f3f4f6;color:#4b5563}
 
+/* severity pills for CVE page */
+.pill-severity-critical { background: #fde8e8; color: #7b1111; border: 1px solid #f5c6c6; }
+.pill-severity-high     { background: #fef0e6; color: #7a3200; border: 1px solid #f8d5b5; }
+.pill-severity-medium   { background: #fef9e6; color: #6b4f00; border: 1px solid #f5e8a0; }
+.pill-severity-low      { background: #eaf6ee; color: #1a5c30; border: 1px solid #b3dfc0; }
+
+/* CVE list page */
+.security-cve-band {
+  h3 {
+    display: flex;
+    align-items: center;
+    gap: 0.6em;
+    margin-bottom: 0.25rem;
+  }
+  .cve-details-table {
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+    width: 100%;
+    th, td {
+      padding: 0.4rem 0.75rem;
+      border: 1px solid #e0e0e0;
+      font-size: 1rem;
+      vertical-align: top;
+    }
+    th {
+      background-color: #f5f7fa;
+      font-weight: 600;
+      white-space: nowrap;
+      color: $dark-blue;
+      width: 160px;
+    }
+  }
+}
+
 /* mobile goes to card format  */
 @media (max-width: 700px) {
   .talk-table thead { display: none; }

--- a/security.md
+++ b/security.md
@@ -1,0 +1,5 @@
+---
+layout: security
+title: Security
+permalink: /security/
+---


### PR DESCRIPTION
### Type of change

- Other

### Description

Close #558,
Adds a security page listing publicly disclosed CVEs affecting Strimzi components, including affected versions, fixed versions, and links to GitHub security advisories.

### Screenshot

- Security Page

<img width="1512" height="825" alt="image" src="https://github.com/user-attachments/assets/454c9ad3-b586-43ca-9258-5be57b1539cc" />

- Resources Page

<img width="1512" height="732" alt="image" src="https://github.com/user-attachments/assets/926d0a5f-a3a5-4681-8485-465b16e35849" />

- Download Page

<img width="1512" height="822" alt="image" src="https://github.com/user-attachments/assets/418de725-75b5-4389-9bda-965e9d62c1bc" />

### Checklist

- [x] AI assistance was used to create this PR