### PR TITLE
Add kapa.ai AI search widget to documentation pages

### DIFF
--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -18,4 +18,15 @@
  
     gtag('config', 'UA-125249459-1');
   </script>
+  {% if page.url contains '/documentation/' or page.url contains '/docs/' %}
+  <!-- kapa.ai AI search widget, loaded on documentation pages only -->
+  <script
+    async
+    src="https://widget.kapa.ai/kapa-widget.bundle.js"
+    data-website-id="44c60ac1-4b4a-466d-ac6a-e775da1e39a8"
+    data-project-name="Strimzi"
+    data-project-color="#182C46"
+    data-project-logo="{{ '/assets/images/strimzi_logo.png' | absolute_url }}"
+  ></script>
+  {% endif %}
 </head>

--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -18,15 +18,15 @@
  
     gtag('config', 'UA-125249459-1');
   </script>
-  {% if page.url contains '/documentation/' or page.url contains '/docs/' %}
-  <!-- kapa.ai AI search widget, loaded on documentation pages only -->
+  <!-- kapa.ai AI search widget -->
   <script
     async
     src="https://widget.kapa.ai/kapa-widget.bundle.js"
-    data-website-id="44c60ac1-4b4a-466d-ac6a-e775da1e39a8"
+    data-website-id="054efed9-adcb-49cd-bde9-3c5dfa2971c4"
     data-project-name="Strimzi"
     data-project-color="#182C46"
-    data-project-logo="{{ '/assets/images/strimzi_logo.png' | absolute_url }}"
+    data-project-logo="{{ '/assets/images/strimzi-icon.svg' | absolute_url }}"
+    data-launcher-button-height="6rem"
+    data-launcher-button-width="5.5rem"
   ></script>
-  {% endif %}
 </head>


### PR DESCRIPTION
~Scope the widget to /documentation/ and /docs/ pages to match the kapa.ai integration's domain allowlist.~

Assisted-by: Copilot <223556219+Copilot@users.noreply.github.com>

### Type of change

_Select the type of your PR and delete the other items_

- Other

### Description

Adding kapa.ai search widget to the website.

### Checklist

- [x] AI assistance was used to create this PR