### PR TITLE
Add Drain Cleaner 1.6.1 to the Helm Chart index

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -2,6 +2,25 @@ apiVersion: v1
 entries:
   strimzi-drain-cleaner:
   - apiVersion: v2
+    appVersion: 1.6.1
+    created: "2026-07-07T21:52:13.350584+02:00"
+    description: Utility which helps with moving the Apache Kafka pods deployed by
+      Strimzi from Kubernetes nodes which are being drained.
+    digest: ce84b8ddcd105f1b10d085fe69ed0d9185f798d009de3fba967386af2b8f6fdd
+    home: https://strimzi.io/
+    icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
+    maintainers:
+    - email: cncf-strimzi-maintainers@lists.cncf.io
+      name: Strimzi Project Maintainers
+      url: https://github.com/strimzi/governance
+    name: strimzi-drain-cleaner
+    sources:
+    - https://github.com/strimzi/drain-cleaner
+    type: application
+    urls:
+    - https://github.com/strimzi/drain-cleaner/releases/download/1.6.1/strimzi-drain-cleaner-helm-3-chart-1.6.1.tgz
+    version: 1.6.1
+  - apiVersion: v2
     appVersion: 1.6.0
     created: "2026-05-05T20:04:14.167685+02:00"
     description: Utility which helps with moving the Apache Kafka pods deployed by
@@ -2212,4 +2231,4 @@ entries:
     urls:
     - https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.6.0/strimzi-kafka-operator-0.6.0.tgz
     version: 0.6.0
-generated: "2026-06-26T19:23:28.601009+02:00"
+generated: "2026-07-07T21:52:13.348911+02:00"


### PR DESCRIPTION
### Type of change

- Other

### Description

This PR adds the Drain Clener 1.6.1 release to the Helm Chart index hosted on the website.